### PR TITLE
Handle getEnv null pointer error in pMarineViewer for docker launch

### DIFF
--- a/ivp/src/pMarineViewer/main.cpp
+++ b/ivp/src/pMarineViewer/main.cpp
@@ -104,8 +104,9 @@ int main(int argc, char *argv[])
     return(-1);
   }
   gui->setTitleBase(title_base);
-  string user = getenv("USER");
-  gui->augmentTitleWithUser(user);
+  if(getenv("USER")) {
+    gui->augmentTitleWithUser(getenv("USER"));
+  }
   gui->setVerbose(verbose);
 
   // See the random number generator


### PR DESCRIPTION
When using docker containers, USER env variable is unset
Due to this, the pMarineViewer crashes with the following log

pMarineViewer launching as pMarineViewer

terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Aborted (core dumped)
