### PR TITLE
Initialize uLoadWatch Breach and Near Breach Count at startup

### DIFF
--- a/ivp/src/uLoadWatch/LoadWatch.cpp
+++ b/ivp/src/uLoadWatch/LoadWatch.cpp
@@ -139,6 +139,11 @@ bool LoadWatch::OnStartUp()
       reportUnhandledConfigWarning(orig);
 
   }
+
+  //Initialize ULW Breach Vars
+
+  Notify("ULW_BREACH_COUNT", m_breach_count);
+  Notify("ULW_NEAR_BREACH_COUNT", m_near_breach_count);
   
   registerVariables();	
   return(true);


### PR DESCRIPTION
Initialized Breach Count variables during onStartup in uLoadWatch in order to use them as pass conditions for automated testing on the 01-Berta mission. Previously, when using pMissionEval to test "pass_condition = ULW_BREACH_COUNT = 0" ULW_BREACH_COUNT was never published until a breach occurred. The same for ULW_NEAR_BREACH_COUNT. Tested the change using a modified 01-Berta mission.