### PR TITLE
[nsplug | PIDEngine | NodeRecord] Handling absolute paths in nsplug automatically. Allowing for negative thrust in PIDEngine. Correctly handling yaw if set in node report

### DIFF
--- a/ivp/src/app_nsplug/Expander.cpp
+++ b/ivp/src/app_nsplug/Expander.cpp
@@ -540,6 +540,10 @@ string Expander::containsMacro(string line)
 string Expander::findFileInPath(string filename)
 {
   unsigned int i, vsize = m_path.size();
+  // override relative pathing when an absolute path is detected
+  if(filename[0] == '/')
+    return filename;
+
   if(vsize == 0)
     return(filename);
 

--- a/ivp/src/dep_pMarinePID/MarinePID.cpp
+++ b/ivp/src/dep_pMarinePID/MarinePID.cpp
@@ -279,8 +279,6 @@ bool MarinePID::Iterate()
 
   m_paused = false;
 
-  if(thrust ==0)
-    rudder = 0;
   Notify("DESIRED_RUDDER", rudder);
   Notify("DESIRED_THRUST", thrust);
   m_current_thrust = thrust;

--- a/ivp/src/lib_contacts/NodeRecord.cpp
+++ b/ivp/src/lib_contacts/NodeRecord.cpp
@@ -235,9 +235,8 @@ string NodeRecord::getSpec(bool terse) const
   if(m_thrust_mode_reverse)
     str += ",THRUST_MODE_REVERSE=true";
 
-  if(m_yaw_set && !terse) 
-    str += ",YAW=" + doubleToStringX(headingToRadians(m_heading),7);
-    //str += ",YAW="  + doubleToStringX(m_heading,2);
+  if(!terse) 
+    str += ",YAW=" + doubleToStringX(m_yaw_set ? m_yaw : headingToRadians(m_heading),7); 
   if(m_timestamp_set)
     str += ",TIME=" + doubleToStringX(m_timestamp,2);
   if(m_transparency_set)

--- a/ivp/src/lib_marine_pid/PIDEngine.cpp
+++ b/ivp/src/lib_marine_pid/PIDEngine.cpp
@@ -317,11 +317,8 @@ void PIDEngine::setDesiredValues()
   // zero others desired values will automatically be zero too.
   //=============================================================
   m_desired_thrust = setDesiredThrust();
-  
-  if(m_desired_thrust > 0)
-    m_desired_rudder = setDesiredRudder();
-  
-  if(m_desired_thrust > 0 && m_depth_control) 
+  m_desired_rudder = setDesiredRudder();
+  if(m_depth_control)
     m_desired_elevator = setDesiredElevator();
 }
 
@@ -469,9 +466,6 @@ double PIDEngine::setDesiredThrust()
     m_speed_pid.Run(speed_error,  m_curr_time, delta_thrust);
     desired_thrust += delta_thrust;
   }
-  
-  if(desired_thrust < 0.01)
-    desired_thrust = 0;
 
   // Enforce limit on desired thrust
   if(desired_thrust > m_max_thrust)


### PR DESCRIPTION

Summary of Proposed Changes
    
**Nsplug Handling of Absolute Paths**
By default, nsplug assumes paths are relative to the current directory. This patch allows nsplug to handle absolute paths automatically by modifying Expander::findFileInPath.
    
**NodeRecord Handling of Direct Yaw Inputs**
Currently, NodeRecord::getSpec derives yaw from m_heading, even when m_yaw has been explicitly set. This patch ensures that m_yaw is used when available, maintaining the original fallback to m_heading.
    
**Negative Thrust Handling in PID Engine**
The PIDEngine does not currently support negative thrust values. The existing logic sets any thrust below 0.01 to zero and only applies desired rudder and elevator values if thrust is positive. This patch removes these constraints, allowing for proper handling of negative thrust.
