### PR TITLE
1.Mods to waypoint behavior allow point=start and points=empty options.

### DIFF
--- a/editor-modes/moos-apps.el
+++ b/editor-modes/moos-apps.el
@@ -86,6 +86,7 @@
       '("pPoseKeep" "hold_tolerance" "hold_duration" "endflag" "hold_heading")
       '("uFldHazardSensor" "term_report_interval" "max_appcast_events" "max_appcast_run_warnings" "default_hazard_shape" "default_hazard_color" "default_hazard_width" "default_benign_shape" "default_benign_color" "default_benign_width" "swath_transparency" "sensor_config" "hazard_file" "swath_length" "seed_random" "show_hazards" "show_swath" "show_detections" "show_reports" "show_pd" "show_pfa" "min_reset_interval" "min_classify_interval" "options_summary_interval")
       '("uFldHazardMgr" "swath_width" "sensor_pd" "report_name" "region" "pd" "max_appcast_events")
+      '("pPointAssignEval")
       '("uFldHazardMetric" "penalty_missed_hazard" "penalty_false_alarm" "penalty_max_time_over" "penalty_max_time_rate" "max_time" "hazard_file" "show_xpath" "max_appcast_events")
       '("uFldMessageHandler" "strict_addressing" "aux_info" "max_appcast_events" "msg_flag" "bad_msg_flag" "aux_info" "app_logging" "appcast_trunc_msg")
       '("uMACView" "procs_font_size" "nodes_font_size" "appcast_font_size" "appcast_color_scheme" "appcast_height" "refresh_mode" "content_mode" "watch_cluster" "realmcast_channel")

--- a/ivp/src/lib_behaviors-marine/BHV_Waypoint.cpp
+++ b/ivp/src/lib_behaviors-marine/BHV_Waypoint.cpp
@@ -165,10 +165,15 @@ void BHV_Waypoint::onSetParamComplete()
   unsigned int repeats = m_waypoint_engine.getRepeats(); 
 
   cout << "wpts: " << wpts << endl;
-  cout << "repeatss: " << repeats << endl;
+  cout << "repeats: " << repeats << endl;
   
   if((wpts == 1) && (repeats > 0))
     postWMessage("cycles/repeats not supported with single waypt");
+  
+  if((m_waypoint_engine.size() == 0) && (m_waypts_init != "empty"))
+    postWMessage("No waypts given. Set val to empty if intentional");
+  else
+    postRetractWMessage("No waypts given. Set val to empty if intentional");
   
   postConfigStatus();
 }
@@ -186,6 +191,11 @@ bool BHV_Waypoint::setParam(string param, string param_val)
   string param_val_lower = tolower(param_val);
 
   if((param == "polygon") || (param == "points") || (param == "xpoints")) {
+    if(param_val_lower == "empty") {
+      m_waypts_init = "empty";
+      return(true);
+    }
+      
     XYSegList new_seglist = string2SegList(param_val);
     if(new_seglist.size() == 0) {
       XYPolygon new_poly = string2Poly(param_val);
@@ -221,6 +231,14 @@ bool BHV_Waypoint::setParam(string param, string param_val)
       m_prev_cycle_index = prev_cycle_ix;
     }
     
+    return(true);
+  }
+  else if((param == "point") && (param_val_lower == "start")) {
+    m_waypts_init = "start";
+    return(true);
+  }
+  else if((param == "point") && (param_val_lower == "empty")) {
+    m_waypts_init = "empty";
     return(true);
   }
   else if(param == "point") {
@@ -502,6 +520,11 @@ BehaviorReport BHV_Waypoint::onRunState(string input)
 
 IvPFunction *BHV_Waypoint::onRunState() 
 {
+  // Added by mikerb Mar1825. Allow a behavior w/ empty set of 
+  // points to be in idle state until an updates is received
+  if(m_waypoint_engine.size() == 0)
+    return(0);
+  
   m_waypoint_engine.setPerpetual(m_perpetual);
 
   // Set m_osx, m_osy, m_osv, osh
@@ -598,6 +621,29 @@ void BHV_Waypoint::onIdleState()
 {
   if(!updateInfoIn()) 
     return;
+}
+
+//-----------------------------------------------------------
+// Procedure: onEveryState()
+
+void BHV_Waypoint::onEveryState(string str) 
+{
+  if(m_waypoint_engine.size() == 0) {
+    if(m_waypts_init == "start") {
+      if(getBufferIsKnown("NAV_X") && getBufferIsKnown("NAV_Y")) {
+	double dbl_navx = getBufferDoubleVal("NAV_X");
+	double dbl_navy = getBufferDoubleVal("NAV_Y");
+	string str_navx = doubleToStringX(dbl_navx,3);
+	string str_navy = doubleToStringX(dbl_navy,3);
+	string param_val = "x=" + str_navx + ",y=" + str_navy;
+	setParam("point", param_val);
+      }
+    }
+    
+    if(m_waypts_init == "end") {
+      setParam("point", "x=0,y=40");
+    }
+  }
 }
 
 //-----------------------------------------------------------

--- a/ivp/src/lib_behaviors-marine/BHV_Waypoint.h
+++ b/ivp/src/lib_behaviors-marine/BHV_Waypoint.h
@@ -41,6 +41,7 @@ public:
   void           onIdleToRunState();
   BehaviorReport onRunState(std::string);
   void           onRunToIdleState();
+  void           onEveryState(std::string s="");
   void           onSetParamComplete();
   void           onCompleteState() {postErasables();}
   void           postConfigStatus();
@@ -77,6 +78,8 @@ protected: // configuration parameters
   std::string m_efficiency_measure;
   std::string m_ipf_type;
 
+  std::string m_waypts_init;
+  
   // Configurable names of MOOS variables for reports
   std::string m_var_report;
   std::string m_var_index;

--- a/ivp/src/lib_geometry/XYFormatUtilsPoint.cpp
+++ b/ivp/src/lib_geometry/XYFormatUtilsPoint.cpp
@@ -65,10 +65,10 @@ XYPoint stringStandard2Point(const string& str)
   vector<string> mvector = parseString(str, ',');
   unsigned int i, vsize = mvector.size();
   
-  string x,y,z,trans;
+  string x,y,z,trans,shiftx,shifty,shiftz;
   string hdg; // Allow for heading spec to be just ignored
   for(i=0; i<vsize; i++) {
-    string param = biteStringX(mvector[i], '=');
+    string param = tolower(biteStringX(mvector[i], '='));
     string value = mvector[i];
 
     if(param == "x")
@@ -77,8 +77,14 @@ XYPoint stringStandard2Point(const string& str)
       y = value;
     else if(param == "z")
       z = value;
-    else if(param == "heading")
+    else if((param == "heading") || (param == "hdg"))
       hdg = value;
+    else if(param == "shiftx")
+      shiftx = value;
+    else if(param == "shifty")
+      shifty = value;
+    else if(param == "shiftz")
+      shiftz = value;
     else if((param == "trans") && isNumber(value))
       trans = value;
     else
@@ -90,8 +96,19 @@ XYPoint stringStandard2Point(const string& str)
 
   if(trans != "")
     new_point.set_transparency(atof(trans.c_str()));
+
+  double dx = atof(x.c_str());
+  double dy = atof(y.c_str());
+  double dz = atof(x.c_str());
+
+  if((shiftx != "") && isNumber(shiftx))
+    dx += atof(shiftx.c_str());
+  if((shifty != "") && isNumber(shifty))
+    dy += atof(shifty.c_str());
+  if((shiftz != "") && isNumber(shiftz))
+    dz += atof(shiftz.c_str());
   
-  new_point.set_vertex(atof(x.c_str()), atof(y.c_str()), atof(z.c_str()));
+  new_point.set_vertex(dx, dy, dz);
   
   return(new_point);
 }

--- a/ivp/src/lib_geometry/XYFormatUtilsPoint.h
+++ b/ivp/src/lib_geometry/XYFormatUtilsPoint.h
@@ -58,13 +58,3 @@ XYPoint stringStandard2Point(const std::string&);
 XYPoint stringAbbreviated2Point(const std::string&);
 
 #endif
-
-
-
-
-
-
-
-
-
-

--- a/ivp/src/lib_geometry/XYFormatUtilsPoly.cpp
+++ b/ivp/src/lib_geometry/XYFormatUtilsPoly.cpp
@@ -411,6 +411,9 @@ XYPolygon stringRadial2Poly(string str)
   double radius = 0;
   double snap = 0;
   int    pts = 0;
+
+  double shiftx = 0;
+  double shifty = 0;
   
   str = stripBlankEnds(str);
   vector<string> mvector = parseStringQ(str, ',');
@@ -436,6 +439,10 @@ XYPolygon stringRadial2Poly(string str)
       //zval_set = true;
       zval = atof(value.c_str());
     }
+    else if((param == "shiftx") && (isNumber(value)))
+      shiftx = atof(value.c_str());
+    else if((param == "shifty") && (isNumber(value)))
+      shifty = atof(value.c_str());
     else if((param == "active") && (tolower(value)=="false")) {
       null_poly.set_active(false);
       new_poly.set_active(false);
@@ -465,6 +472,9 @@ XYPolygon stringRadial2Poly(string str)
 
   if(!xpos_set || !ypos_set || !radius_set || !pts_set)
     return(null_poly);
+
+  xpos += shiftx;
+  ypos += shifty;
   
   // The "false" parameter in add_vertex() below indicates that a
   // convexity determination is *not* to be made as part of the call


### PR DESCRIPTION
1. Mods to waypoint behavior allow point=start and points=empty options.
2. Mods to XYFormatUtils to support ignoring heading= or hdg= components so that "start positions" like x=1,y=2,heading=180 are not rejected as destination points.
3. updated moos emacs mode