### PR TITLE
Bugfix in uFldNodeComms, ContactLedger re: inter-vehicle group name/all handling

### DIFF
--- a/ivp/src/lib_geodaid/ContactLedger.cpp
+++ b/ivp/src/lib_geodaid/ContactLedger.cpp
@@ -737,6 +737,11 @@ CPList ContactLedger::getVHist(string vname) const
 set<string> ContactLedger::getVNamesByGroup(string group) const
 {
   set<string> rset;
+
+  // Apr 13th, 2025: Group match MUST be matching non-empty strings
+  group = stripBlankEnds(group);
+  if(group == "")
+    return(rset);
   
   map<string,NodeRecord>::const_iterator p;
   for(p=m_map_records_rep.begin(); p!=m_map_records_rep.end(); p++) {

--- a/ivp/src/uFldMessageHandler/MessageHandler.cpp
+++ b/ivp/src/uFldMessageHandler/MessageHandler.cpp
@@ -193,6 +193,10 @@ bool MessageHandler::handleMailNodeMessage(const string& msg)
   string var_sval   = message.getStringVal();
   if(isQuoted(var_sval))
     var_sval = stripQuotes(var_sval);
+
+  // Allow dest_node=ALL to be treated case insensitive 
+  if(dest_node == "ALL")
+    dest_node = "all";
   
   bool is_string = true;
   if(var_sval == "")

--- a/ivp/src/uFldNodeComms/FldNodeComms.cpp
+++ b/ivp/src/uFldNodeComms/FldNodeComms.cpp
@@ -674,7 +674,7 @@ void FldNodeComms::distributeNodeMessageInfo(string src_name,
   string msg_color = m_msg_color;
   if(message.getColor() != "")
     msg_color = message.getColor();
-  
+
   // Part 1: Begin determining the list of destinations
   // Examples: dest=ben, dest=abe:ben, dest=all, 
   set<string> dest_names;
@@ -684,6 +684,8 @@ void FldNodeComms::distributeNodeMessageInfo(string src_name,
   string dest_name  = message.getDestNode();
   string dest_group = message.getDestGroup();
   if((dest_name == "ALL") || (dest_group == "ALL"))
+    all = true;
+  if((dest_name == "all") || (dest_group == "all"))
     all = true;
 
   if(all)


### PR DESCRIPTION
Bugfix in uFldNodeComms in handling messages with dest_name=all usage and ContractLedger to insist that group match be non-empty group name. Using dest_name=all or dest_name=ALL are supported equally.