### PR TITLE
mods to support filtering contact behaviors based on contact source info

### DIFF
--- a/ivp/src/lib_behaviors/IvPBehavior.cpp
+++ b/ivp/src/lib_behaviors/IvPBehavior.cpp
@@ -1680,6 +1680,7 @@ double IvPBehavior::getBufferDoubleVal(string varname, bool& ok)
   }
   if((!ok) && !vectorContains(m_info_vars_no_warning, varname))     
     postWMessage(varname + " dbl info not found in helm info_buffer");
+  
   return(value);
 }
 

--- a/ivp/src/lib_behaviors/IvPContactBehavior.h
+++ b/ivp/src/lib_behaviors/IvPContactBehavior.h
@@ -99,6 +99,7 @@ public:
 
   std::string m_cn_group;
   std::string m_cn_vtype;
+  std::string m_cn_vsource; // Added 4/11/25 contac info src, e.g., radar, ais
 
   double m_relevance;
 

--- a/ivp/src/lib_bhvutil/ExFilterSet.cpp
+++ b/ivp/src/lib_bhvutil/ExFilterSet.cpp
@@ -84,6 +84,11 @@ bool ExFilterSet::setStrictIgnore(string str)
   return(setBooleanOnString(m_strict_ignore, str));
 }
 
+
+//===========================================================
+//                                                       NAME
+//===========================================================
+
 // ----------------------------------------------------------
 // Procedure: addIgnoreName()
 //   Example: "hal" or "hal,abe" or "{hal,abe}"
@@ -131,6 +136,32 @@ bool ExFilterSet::addMatchName(string str)
   return(all_ok);
 }
 
+// ----------------------------------------------------------
+// Procedure: removeIgnoreName()
+
+bool ExFilterSet::removeIgnoreName(string vname)
+{
+  m_ignore_names.erase(vname);
+  m_ignore_names.erase(tolower(vname));
+  return(true);
+}
+
+// ----------------------------------------------------------
+// Procedure: removeMatchName()
+
+bool ExFilterSet::removeMatchName(string vname)
+{
+  m_match_names.erase(vname);
+  m_match_names.erase(tolower(vname));
+  return(true);
+}
+
+
+
+
+//===========================================================
+//                                                      GROUP
+//===========================================================
 
 // ----------------------------------------------------------
 // Procedure: addIgnoreGroup()
@@ -181,6 +212,30 @@ bool ExFilterSet::addMatchGroup(string str)
 
 
 // ----------------------------------------------------------
+// Procedure: removeIgnoreGroup()
+
+bool ExFilterSet::removeIgnoreGroup(string group)
+{
+  m_ignore_groups.erase(group);
+  m_ignore_groups.erase(tolower(group));
+  return(true);
+}
+
+// ----------------------------------------------------------
+// Procedure: removeMatchGroup()
+
+bool ExFilterSet::removeMatchGroup(string group)
+{
+  m_match_groups.erase(group);
+  m_match_groups.erase(tolower(group));
+  return(true);
+}
+
+//===========================================================
+//                                                       TYPE
+//===========================================================
+
+// ----------------------------------------------------------
 // Procedure: addIgnoreType()
 //   Example: "uuv" or "uuv,usv" or "{uuv,usv}"
 //   Returns: false if a given type is already a match type
@@ -225,6 +280,104 @@ bool ExFilterSet::addMatchType(string str)
   }
   return(all_ok);
 }
+
+// ----------------------------------------------------------
+// Procedure: removeIgnoreType()
+
+bool ExFilterSet::removeIgnoreType(string vtype)
+{
+  m_ignore_types.erase(vtype);
+  m_ignore_types.erase(tolower(vtype));
+  return(true);
+}
+
+// ----------------------------------------------------------
+// Procedure: removeMatchType()
+
+bool ExFilterSet::removeMatchType(string vtype)
+{
+  m_match_types.erase(vtype);
+  m_match_types.erase(tolower(vtype));
+  return(true);
+}
+
+
+//===========================================================
+//                                                     SOURCE
+//===========================================================
+
+// ----------------------------------------------------------
+// Procedure: addIgnoreSource()
+//   Example: "ais" or "ais,camera" or "{ais,camera}" or "ownship"
+//   Returns: false if a given type is already a match source
+//            (cannot be both on the match list and ignore list)
+
+bool ExFilterSet::addIgnoreSource(string str)
+{
+  // All sources are treated as case insensitive
+  str = stripBraces(stripBlankEnds(tolower(str)));
+
+  bool all_ok = true;
+
+  vector<string> svector = parseString(str, ',');
+  for(unsigned int i=0; i<svector.size(); i++) {
+    string vsource = svector[i];
+    if(m_match_sources.count(vsource))
+      all_ok = false;
+    else
+      m_ignore_sources.insert(vsource);
+  }
+  return(all_ok);
+}
+
+// ----------------------------------------------------------
+// Procedure: addMatchSource()
+//   Example: "ais" or "ais,camera" or "{ais,camera}" or "ownship"
+//   Returns: false if a given type is already an ignore source
+//            (cannot be both on the match list and ignore list)
+
+bool ExFilterSet::addMatchSource(string str)
+{
+  // All sources are treated case insensitive
+  str = stripBraces(stripBlankEnds(tolower(str)));
+  
+  bool all_ok = true;
+
+  vector<string> svector = parseString(str, ',');
+  for(unsigned int i=0; i<svector.size(); i++) {
+    string vsource = svector[i];
+    if(m_ignore_sources.count(vsource))
+      all_ok = false;
+    else
+      m_match_sources.insert(vsource);
+  }
+  return(all_ok);
+}
+
+// ----------------------------------------------------------
+// Procedure: removeIgnoreSource()
+
+bool ExFilterSet::removeIgnoreSource(string vsource)
+{
+  m_ignore_sources.erase(vsource);
+  m_ignore_sources.erase(tolower(vsource));
+  return(true);
+}
+
+// ----------------------------------------------------------
+// Procedure: removeMatchSource()
+
+bool ExFilterSet::removeMatchSource(string vsource)
+{
+  m_match_sources.erase(vsource);
+  m_match_sources.erase(tolower(vsource));
+  return(true);
+}
+
+
+//===========================================================
+//                                                     REGION
+//===========================================================
 
 // ----------------------------------------------------------
 // Procedure: addIgnoreRegion()

--- a/ivp/src/lib_bhvutil/ExFilterSet.h
+++ b/ivp/src/lib_bhvutil/ExFilterSet.h
@@ -39,15 +39,35 @@ class ExFilterSet
 
  public: // setters
 
+  // NAME
   bool addIgnoreName(std::string);
   bool addMatchName(std::string);
+  bool removeIgnoreName(std::string);   // Added Apr1025
+  bool removeMatchName(std::string);    // Added Apr1025
+
+  // GROUP
   bool addIgnoreGroup(std::string);
   bool addMatchGroup(std::string);
+  bool removeIgnoreGroup(std::string);  // Added Apr1025
+  bool removeMatchGroup(std::string);   // Added Apr1025
+
+  // TYPE
   bool addIgnoreType(std::string);
   bool addMatchType(std::string);
+  bool removeIgnoreType(std::string);   // Added Apr1025
+  bool removeMatchType(std::string);    // Added Apr1025
+
+  // SOURCE
+  bool addIgnoreSource(std::string);    // Added Apr1025
+  bool addMatchSource(std::string);     // Added Apr1025
+  bool removeIgnoreSource(std::string); // Added Apr1025
+  bool removeMatchSource(std::string);  // Added Apr1025
+  
+  // REGION
   bool addIgnoreRegion(std::string);
   bool addMatchRegion(std::string);
-
+  
+ public:
   bool setOwnshipGroup(std::string);
   bool setOwnshipType(std::string);
   
@@ -63,6 +83,7 @@ class ExFilterSet
   bool filterCheckGroup(std::string group) const;
   bool filterCheckVType(std::string vtype) const;
   bool filterCheckVName(std::string vtype) const;
+  bool filterCheckVSource(std::string vsource) const;
   bool filterCheckRegion(double cnx, double cny) const;
   
  public: // Serialization
@@ -85,6 +106,9 @@ class ExFilterSet
 
   std::set<std::string> m_ignore_types;
   std::set<std::string> m_match_types;
+
+  std::set<std::string> m_ignore_sources;
+  std::set<std::string> m_match_sources;
 
   std::vector<XYPolygon>   m_ignore_regions;
   std::vector<XYPolygon>   m_match_regions;

--- a/ivp/src/lib_contacts/NodeRecord.cpp
+++ b/ivp/src/lib_contacts/NodeRecord.cpp
@@ -211,6 +211,8 @@ string NodeRecord::getSpec(bool terse) const
     str += ",COLOR=" + m_color;
   if(m_group != "")
     str += ",GROUP=" + m_group;
+  if(m_vsource != "")
+    str += ",VSOURCE=" + m_vsource;
   if(m_mode != "")
     str += ",MODE=" + m_mode;
   if(m_mode_aux != "")
@@ -277,6 +279,16 @@ string NodeRecord::getGroup(string default_group) const
   if(m_group == "")
     return(default_group);
   return(m_group);
+}
+
+//---------------------------------------------------------------
+// Procedure: getVSource()
+
+string NodeRecord::getVSource(string default_vsource) const
+{
+  if(m_vsource == "")
+    return(default_vsource);
+  return(m_vsource);
 }
 
 //---------------------------------------------------------------

--- a/ivp/src/lib_contacts/NodeRecord.h
+++ b/ivp/src/lib_contacts/NodeRecord.h
@@ -57,6 +57,7 @@ class NodeRecord
   void setName(std::string s)    {m_name=s;}
   void setGroup(std::string s)   {m_group=s;}
   void setType(std::string s)    {m_type=s;}
+  void setVSource(std::string s) {m_vsource=s;}
   void setColor(std::string s)   {m_color=s;}
   void setMode(std::string s)    {m_mode=s;}
   void setModeAux(std::string s) {m_mode_aux=s;}
@@ -118,6 +119,7 @@ class NodeRecord
   std::string getName(std::string s="") const;
   std::string getGroup(std::string s="") const;
   std::string getType(std::string s="") const;
+  std::string getVSource(std::string s="") const;
   std::string getColor(std::string s="") const;
   std::string getMode(std::string s="") const;
   std::string getModeAux(std::string s="") const;
@@ -150,7 +152,9 @@ class NodeRecord
   std::string  m_name;
   std::string  m_group;
   std::string  m_type;
+  std::string  m_vsource;
   std::string  m_color;
+
   std::string  m_mode;
   std::string  m_mode_aux;
   std::string  m_allstop;

--- a/ivp/src/lib_contacts/NodeRecordUtils.cpp
+++ b/ivp/src/lib_contacts/NodeRecordUtils.cpp
@@ -83,13 +83,13 @@ NodeRecord extrapolateRecord(const NodeRecord& record, double curr_time,
 //   Example: NAME=alpha,TYPE=KAYAK,UTC_TIME=1267294386.51,
 //            X=29.66,Y=-23.49,LAT=43.825089, LON=-70.330030, 
 //            SPD=2.00, HDG=119.06,YAW=119.05677,DEPTH=0.00,     
-//            LENGTH=4.0,MODE=DRIVE,GROUP=A
+//            LENGTH=4.0,MODE=DRIVE,GROUP=A,VSOURCE=ais
 //   Or:
 //
 //   Example: {"NAME":"alpha","TYPE":"KAYAK","UTC_TIME":"1267294386.51",
 //            "X":"29.66","Y":"-23.49","LAT":"43.825089","LON"="-70.330030", 
 //            "SPD":"2.00","HDG":"119.06","YAW":"119.05677","DEPTH"="0.00",     
-//            "LENGTH":"4.0","MODE":"DRIVE","GROUP":"A"}
+//            "LENGTH":"4.0","MODE":"DRIVE","GROUP":"A","VSOURCE":"ais"}
 
 
 NodeRecord string2NodeRecord(const string& node_rep_string)
@@ -105,7 +105,7 @@ NodeRecord string2NodeRecord(const string& node_rep_string)
 //   Example: NAME=alpha,TYPE=KAYAK,UTC_TIME=1267294386.51,
 //            X=29.66,Y=-23.49,LAT=43.825089, LON=-70.330030, 
 //            SPD=2.00, HDG=119.06,YAW=119.05677,DEPTH=0.00,     
-//            LENGTH=4.0,MODE=DRIVE,GROUP=A
+//            LENGTH=4.0,MODE=DRIVE,GROUP=A,VSOURCE=ais
 
 NodeRecord string2NodeRecordCSP(const string& node_rep_string)
 {
@@ -167,6 +167,8 @@ NodeRecord string2NodeRecordCSP(const string& node_rep_string)
       new_record.setColor(value);
     else if(param == "GROUP")
       new_record.setGroup(value);
+    else if(param == "VSOURCE")
+      new_record.setVSource(value);
     else if(param == "LOAD_WARNING")
       new_record.setLoadWarning(value);
     else if((param == "THRUST_MODE_REVERSE") && (tolower(value) == "true")) 
@@ -186,7 +188,7 @@ NodeRecord string2NodeRecordCSP(const string& node_rep_string)
 //   Example: {"NAME":"alpha","TYPE":"KAYAK","UTC_TIME":"1267294386.51",
 //            "X":"29.66","Y":"-23.49","LAT":"43.825089","LON"="-70.330030", 
 //            "SPD":"2.00","HDG":"119.06","YAW":"119.05677","DEPTH"="0.00",     
-//            "LENGTH":"4.0","MODE":"DRIVE","GROUP":"A"}
+//            "LENGTH":"4.0","MODE":"DRIVE","GROUP":"A","VSOURCE":"ais"}
 
 NodeRecord string2NodeRecordJSON(string report)
 {
@@ -254,6 +256,8 @@ NodeRecord string2NodeRecordJSON(string report)
       new_record.setColor(value);
     else if(param == "GROUP")
       new_record.setGroup(value);
+    else if(param == "VSOURCE")
+      new_record.setVSource(value);
     else if(param == "LOAD_WARNING")
       new_record.setLoadWarning(value);
     else if((param == "THRUST_MODE_REVERSE") && (tolower(value) == "true")) 

--- a/ivp/src/lib_geodaid/ContactLedger.cpp
+++ b/ivp/src/lib_geodaid/ContactLedger.cpp
@@ -676,6 +676,18 @@ string ContactLedger::getGroup(string vname) const
 }
 
 //---------------------------------------------------------------
+// Procedure: getVSource()
+
+string ContactLedger::getVSource(string vname) const
+{
+  if(!hasVName(vname))
+    return("");
+
+  NodeRecord record = getRecord(vname, false);
+  return(record.getVSource());
+}
+
+//---------------------------------------------------------------
 // Procedure: getType()
 
 string ContactLedger::getType(string vname) const

--- a/ivp/src/lib_geodaid/ContactLedger.h
+++ b/ivp/src/lib_geodaid/ContactLedger.h
@@ -81,6 +81,7 @@ public: // Record Getters
   double getUTCAgeReceived(std::string vname) const;
 
   std::string getGroup(std::string vname) const;
+  std::string getVSource(std::string vname) const;
   std::string getType(std::string vname) const;
   std::string getColor(std::string vname) const;
   std::string getSpec(std::string vname) const;

--- a/ivp/src/lib_helmivp/BehaviorSet.cpp
+++ b/ivp/src/lib_helmivp/BehaviorSet.cpp
@@ -182,7 +182,7 @@ void BehaviorSet::connectLedgerSnap(LedgerSnap *lsnap)
 //            the same behaviors. The manner in which filter msgs
 //            are applied, repeated msgs make no difference.
 //   Example: action=disable, contact=345, gen_type=safety,
-//            bhv_type=AvdColregs
+//            bhv_type=AvdColregs, vsource=ais
 //    Fields: action=disable/able  (mandatory)
 //            contact=345          (one of these three)
 //            gen_type=safety

--- a/ivp/src/lib_logic/LedgerSnap.cpp
+++ b/ivp/src/lib_logic/LedgerSnap.cpp
@@ -91,6 +91,24 @@ void LedgerSnap::setUTCAgeReceived(string vname, double dval)
 
 
 //-----------------------------------------------------------
+// Procedure: setGroup(), setType(), setVSource()
+
+void LedgerSnap::setGroup(string vname, string sval)
+{
+  m_map_group[vname] = sval;
+}
+void LedgerSnap::setType(string vname, string sval)
+{
+  m_map_type[vname] = sval;
+}
+void LedgerSnap::setVSource(string vname, string sval)
+{
+  m_map_vsource[vname] = sval;
+}
+
+
+
+//-----------------------------------------------------------
 // Procedure: getInfoDouble()
 
 double LedgerSnap::getInfoDouble(std::string vname,
@@ -180,6 +198,11 @@ string LedgerSnap::getInfoString(std::string vname,
     p = m_map_type.find(vname);
     if(p != m_map_type.end())
       return(p->second);
+  }  
+  else if(fld == "vsource") {
+    p = m_map_vsource.find(vname);
+    if(p != m_map_vsource.end())
+      return(p->second);
   }
   
   ok = false;
@@ -245,6 +268,8 @@ unsigned int LedgerSnap::size() const
     max_size = m_map_group.size();
   if(m_map_type.size() > max_size)
     max_size = m_map_type.size();
+  if(m_map_vsource.size() > max_size)
+    max_size = m_map_vsource.size();
 
   return(max_size);
 }

--- a/ivp/src/lib_logic/LedgerSnap.h
+++ b/ivp/src/lib_logic/LedgerSnap.h
@@ -51,6 +51,7 @@ public:
 
   void setGroup(std::string vname, std::string sval);
   void setType(std::string vname, std::string sval);
+  void setVSource(std::string vname, std::string sval);
 
   void setCurrTimeUTC(double v) {m_curr_time_utc=v;}
   
@@ -84,6 +85,7 @@ protected:
 
   std::map<std::string, std::string> m_map_group;
   std::map<std::string, std::string> m_map_type;
+  std::map<std::string, std::string> m_map_vsource;
 
   double m_curr_time_utc;
 };

--- a/ivp/src/pContactMgrV20/ContactMgrV20_Info.cpp
+++ b/ivp/src/pContactMgrV20/ContactMgrV20_Info.cpp
@@ -201,6 +201,14 @@ void showInterfaceAndExit()
   blk("                      YAW=118.8,DEPTH=4.6,LENGTH=3.8,           ");
   blk("                      MODE=MODE@ACTIVE:LOITERING                ");
   blk("                                                                ");
+  blk("         disable_var = XYZ_DISABLE_TARGET                       ");
+  blk("  XYZ_DISABLE_TARGET = 87933                                    ");
+  blk("  XYZ_DISABLE_TARGET = contact=87933, action=disable            ");
+  blk("                                                                ");
+  blk("          enable_var = XYZ_ENABLE_CONTACT                       ");
+  blk("  XYZ_EMABLE_CONTACT = 45902                                    ");
+  blk("  XYZ_ENABLE_CONTACT = contact=45902, action=enable             ");
+  blk("                                                                ");
   blk("PUBLICATIONS:                                                   ");
   blk("------------------------------------                            ");
   blk("  Alert publications configured by the user.                    ");
@@ -212,6 +220,8 @@ void showInterfaceAndExit()
   blk("                  config_alert_range_cpa=45.0,range_used=39.2,  ");
   blk("                  range_actual=40.8,range_extrap=40.8,          ");
   blk("                  range_cpa=13                                  ");
+  blk("                                                                ");
+  blk("  BHV_ABLE_FILTER        = contact=98732, action=disable        ");
   blk("                                                                ");
   blk("  CONTACT_CLOSEST        = charlie                              ");
   blk("  CONTACT_CLOSEST_TIME   = 17514261063.3                        ");

--- a/ivp/src/pHelmIvP/HelmEngine.cpp
+++ b/ivp/src/pHelmIvP/HelmEngine.cpp
@@ -149,7 +149,7 @@ bool HelmEngine::applyAbleFilterMsgs()
 {
   if(!m_bhv_set)
     return(false);
-  
+
   bool last_msg_ok = true;
   list<string>::iterator p;
   for(p=m_able_filter_msgs.begin(); p!=m_able_filter_msgs.end(); p++) {

--- a/ivp/src/pHelmIvP/HelmIvP.cpp
+++ b/ivp/src/pHelmIvP/HelmIvP.cpp
@@ -1911,6 +1911,10 @@ void HelmIvP::updateLedgerSnap()
     m_ledger_snap->setUTCAge(v, m_ledger.getUTCAge(v));
     m_ledger_snap->setUTCReceived(v, m_ledger.getUTCReceived(v));
     m_ledger_snap->setUTCAgeReceived(v, m_ledger.getUTCAgeReceived(v));
+
+    m_ledger_snap->setGroup(v, m_ledger.getGroup(v));
+    m_ledger_snap->setType(v, m_ledger.getType(v));
+    m_ledger_snap->setVSource(v, m_ledger.getVSource(v));
   }
   m_ledger_snap->setCurrTimeUTC(m_curr_time);
 }

--- a/ivp/src/pHelmIvP/HelmIvP_Info.cpp
+++ b/ivp/src/pHelmIvP/HelmIvP_Info.cpp
@@ -155,11 +155,15 @@ void showInterfaceAndExit()
   blk("  the particular behaviors used in a given configuration, and   ");
   blk("  variables used in helm mode declarations.                     ");
   blk("  +                                                             ");
-  blk("  MOOS_MANUAL_OVERIDE                                           ");
+  blk("  DB_CLIENTS            = pLogger,pRealm,pHelmIvP,pMarinePIDV22 ");
+  blk("                          pNodeReporter,uSimMarineV22           ");
+  blk("  MOOS_MANUAL_OVERIDE   = false                                 ");
   blk("  MOOS_MANUAL_OVERRIDE                                          ");
   blk("  RESTART_HELM                                                  ");
-  blk("  IVPHELM_VERBOSE                                               ");
-  blk("  IVPHELM_REJOURNAL                                             ");
+  blk("  IVPHELM_REJOURNAL     = true                                  ");
+  blk("                                                                ");
+  blk("  BHV_ABLE_FILTER = contact=8745, action=disable                ");
+  blk("                                                                ");
   blk("  APPCAST_REQ  = node=all,app=uFldCollObDetect,duration=3.0     ");
   blk("                 key=pMarineViewer:alphaapp,thresh=run_warning  ");
   blk("                                                                ");

--- a/ivp/src/pNodeReporter/NodeReporter.cpp
+++ b/ivp/src/pNodeReporter/NodeReporter.cpp
@@ -457,6 +457,11 @@ bool NodeReporter::OnStartUp()
       m_group_name = value;
       handled = true;
     }
+    else if((param == "platform_vsource") ||
+	    (param == "vsource")) {
+      m_vsource = value;
+      handled = true;
+    }
     else if(param == "paused")
       handled = setBooleanOnString(m_paused, value);
     else if(param == "nohelm_threshold") {
@@ -548,6 +553,7 @@ bool NodeReporter::OnStartUp()
   
   m_record.setName(m_vessel_name);
   m_record.setGroup(m_group_name);
+  m_record.setVSource(m_vsource);
 
   // To start with m_record_gt is just a copy of m_record.
   m_record_gt = m_record;       

--- a/ivp/src/pNodeReporter/NodeReporter.h
+++ b/ivp/src/pNodeReporter/NodeReporter.h
@@ -71,6 +71,7 @@ public:
   std::string  m_node_report_var;
   double       m_nohelm_thresh;
   std::string  m_group_name;
+  std::string  m_vsource;
   bool         m_terse_reports;
   bool         m_allow_color_change;
 


### PR DESCRIPTION
Adding support to disable contact related behaviors based on the source of information for the contact, e.g., AIS, Radar, and so on. Node reports now support the optional "vsource" field. The contact manager can receive disable and enable messages with the vsource as the criteria. The Helm->HelmEngine->BehaviorSet flow supports the disabling based on vsource criteria. The applyAbleFilter() method for IvPContactBehavior implements the handling of the incoming enable or disable messages 