### PR TITLE
Use `pkill` to kill child jobs from xlaunch

### DIFF
--- a/scripts/xlaunch.sh
+++ b/scripts/xlaunch.sh
@@ -52,7 +52,7 @@ done
 # Part 4: Monitor mission, kill MOOS processes when done
 uMayFinish --max_time=${MAX_TIME} targ_shoreside.moos
 # Part 5: Bring down the launched mission
-kill -s SIGTERM 0
+pkill -INT -P $$
 # Part 6: sleep 2 secs to let mission processes come down.
 sleep 2
 


### PR DESCRIPTION
Currently, using `xlaunch.sh` in a non-interactive manor has different behavior than on an interactive shell. This PR changes the behavior to be consistent across modes by using `pkill`.

To quote the bash [manual](https://www.gnu.org/software/bash/manual/bash.html#Signals):
> When Bash is interactive, in the absence of any traps, it ignores SIGTERM (so that ‘kill 0’ does not kill an interactive shell), and SIGINT is caught and handled (so that the wait builtin is interruptible). When Bash receives a SIGINT, it breaks out of any executing loops. In all cases, Bash ignores SIGQUIT.

This means when running `xlaunch.sh` on a laptop normally, it runs as expected. However, when running in an non-interactive mode (like in CI), we SIGTERM ourselves early before finishing. @cbenjamin23 experienced this in his [github](https://github.com/cbenjamin23/moos-ivp-charlie-github/actions/runs/14986752232/job/42102059489#step:4:75) job, for example.

A semi-notable difference is that `pkill` will exit with exit code `1` if there are no child jobs, while `kill` silently moves on. I expect this is OK behavior, but we can surpress that exit code if you see in issue with this behavior.

I've been using this variant in a few different headless missions of mine for a while to good effect.

To demo, copy and paste this into an interactive shell. `0` exit codes are desireable, while the `143` exit code is not.

```bash
echo "With pkill"
sleep 1

bash -c '
sleep 1 &
pkill -INT -P $$
' ; echo $?

bash -ic '
sleep 1 &
pkill -INT -P $$
' ; echo $?

echo "With kill"
sleep 1
bash -c "kill -s SIGTERM 0"; echo $? # will print 143 (128 + SIGINT) -- this is undesired
bash -ic "kill -s SIGTERM 0"; echo $?

echo "Finished Successfully"
```