### PR TITLE
Minor mods to pSpoofNode

### DIFF
--- a/editor-modes/moos-apps.el
+++ b/editor-modes/moos-apps.el
@@ -43,6 +43,8 @@
 
       '("pAutoPoke" "flag" "required_nodes")
 
+      '("pSpoofNode" "refresh_interval" "default_length" "default_vtype" "default_group" "default_vsource" "default_color" "default_hdg" "default_spd" "default_duration" "spoof")
+
       '("uFldConvoyEval" "recap_var" "stat_recap_var" "spd_policy_var" )
       
       '("uFldVoronoi" "stale_time" "region" "muster_region" "prox_edge_color" "prox_vertex_color" "prox_fill_color" "prox_label_color" "max_appcast_events")

--- a/ivp/src/CMakeLists.txt
+++ b/ivp/src/CMakeLists.txt
@@ -189,7 +189,7 @@ SET(IVP_NON_GUI_APPS
   uFldScope          uFldNodeComms       uFldBeaconRangeSensor
   pSearchGrid        uFldGenericSensor   uFldContactRangeSensor
   uFldDelve          app_bweb            app_mhash_gen
-  app_projfield      pMapMarkers
+  app_projfield      pMapMarkers         pSpoofNode
 )
 SET(IVP_GUI_APPS
   app_ffview         app_geoview         app_alogview

--- a/ivp/src/app_zaic_hdg/main.cpp
+++ b/ivp/src/app_zaic_hdg/main.cpp
@@ -90,6 +90,21 @@ void showHelpAndExit()
 {
   cout << endl;
   cout << "Usage: zaic_hdg [OPTIONS]                           " << endl;
+  cout << "  zaic_hdg [OPTIONS]                                " << endl;
+  cout << "                                                    " << endl;
+  cout << "Synopsis:                                           " << endl;
+  cout << "  The zaic_hdg utility renders a configured instance" << endl;
+  cout << "  of the ZAIC_HDG utility in the ivpbuild toolbox.  " << endl;
+  cout << "  This allow the user to visualize the effects of   " << endl;
+  cout << "  parameter settings for this too. Normally this    " << endl;
+  cout << "  tool is created and parameterized within an IvP   " << endl;
+  cout << "  behavior. This tool may give behavior authors some" << endl;
+  cout << "  insight into how the tool works. This tool was    " << endl;
+  cout << "  also used as an engineering/validatio tool when   " << endl;
+  cout << "  the original C++ code was written. This tool wraps" << endl;
+  cout << "  the very same ZAIC_HDG C++ class as is used in the" << endl;
+  cout << "  behaviors.                                        " << endl;
+  cout << "                                                    " << endl;
   cout << "Options:                                            " << endl;
   cout << "  --help, -h           Display this help message    " << endl;
   cout << "  --domain=360         Set upper value of domain    " << endl;
@@ -102,6 +117,17 @@ void showHelpAndExit()
 }
 
 
+The zaic_hdg utility renders a configured instance 
+of the ZAIC_HDG utility in the ivpbuild toolbox.   
+This allow the user to visualize the effects of    
+parameter settings for this too. Normally this     
+is created and parameterized within an IvP    
+behavior. This tool may give behavior authors some
+insight into how the tool works. This tool was     
+also used as an engineering/validatio tool when    
+the original C++ code was written. This tool wraps 
+the very same ZAIC_HDG C++ class as is used in the 
+behaviors.                                         
 
 
 

--- a/ivp/src/pSpoofNode/SpoofNode.h
+++ b/ivp/src/pSpoofNode/SpoofNode.h
@@ -30,7 +30,7 @@ protected: // Standard MOOSApp functions to overload
 
  protected:
   bool handleConfigDefaultVType(std::string);
-  bool handleMailSpoof(std::string);
+  bool handleSpoofRequest(std::string);
   bool handleMailSpoofCancel(std::string);
 
   void advancePositions(double);
@@ -61,6 +61,7 @@ protected: // Standard MOOSApp functions to overload
   double m_last_posting;
 
   unsigned int m_total_postings;
+  unsigned int m_total_spoof_reqs;
   
   std::map<std::string, NodeRecord> m_map_node_records;
   std::map<std::string, double> m_map_node_durations;

--- a/ivp/src/pSpoofNode/SpoofNode_Info.cpp
+++ b/ivp/src/pSpoofNode/SpoofNode_Info.cpp
@@ -100,7 +100,7 @@ void showExampleConfigAndExit()
 void showInterfaceAndExit()
 {
   blu("=============================================================== ");
-  blu("pSpoofNode INTERFACE                                    ");
+  blu("pSpoofNode INTERFACE                                            ");
   blu("=============================================================== ");
   blk("                                                                ");
   showSynopsis();
@@ -115,7 +115,12 @@ void showInterfaceAndExit()
   blk("                                                                ");
   blk("PUBLICATIONS:                                                   ");
   blk("------------------------------------                            ");
-  blk("  NODE_REPORT =                                                 ");
+  blk("  NODE_REPORT = NAME=ben,X=40.01,Y=-40.01,SPD=0,HDG=180,DEP=0,  ");
+  blk("                LAT=43.82494566,LON=-70.32989454,TYPE=kayak,    ");
+  blk("                COLOR=red,VSOURCE=radar,                        ");
+  blk("                MODE=MODE@ACTIVE:TRANSITING,ALLSTOP=clear,      ");
+  blk("                INDEX=87,YAW=-1.5707963,TIME=7001538254.13,     ");
+  blk("                LENGTH=4                                        ");
   exit(0);
 }
 


### PR DESCRIPTION
Minor mods to pSpoofNode to support configuration of a spoof from the .moos config file, as opposed to solely done through SPOOF postings.