### PR TITLE
Mod to IvPBehavior to only invoke complete for stale contact behavior…

### DIFF
--- a/ivp/src/lib_behaviors/IvPBehavior.cpp
+++ b/ivp/src/lib_behaviors/IvPBehavior.cpp
@@ -337,7 +337,8 @@ string IvPBehavior::isRunnable()
 #endif
 
   if((m_contact != "") && !hasLedgerVName(m_contact))
-    setComplete();
+    if(isDynamicallySpawned()) // Added mikerb Jun2525
+      setComplete();
 
   if(m_completed)
     return("completed");


### PR DESCRIPTION
Mod to IvPBehavior to only invoke setComplete for stale contact behavior if it was dynamically spawned. This fixes a problem with the recent change to allow contact behaviors to self-complete when/if the contact disappears from the helm ledger (presumably due to a period where no NODE_REPORTS have been received for a contact). This was a problem for static contact behaviors with their initial contact name set to something like "to-be-set".