### PR TITLE
added nspatch, mods to nsplug, for better autotesting

### DIFF
--- a/editor-modes/moos-mode.el
+++ b/editor-modes/moos-mode.el
@@ -71,7 +71,12 @@
 ;; _? matches "zero or 1 underscores" so that the mission and behavior
 ;; files copied into Log folders by pLogger open in moos mode.
 (add-to-list 'auto-mode-alist '("\\._?moos\\'" . moos-mode))
+(add-to-list 'auto-mode-alist '("\\._?xmoos\\'" . moos-mode))
+(add-to-list 'auto-mode-alist '("\\._?moosx\\'" . moos-mode))
+
 (add-to-list 'auto-mode-alist '("\\._?bhv\\'" . moos-mode))
+(add-to-list 'auto-mode-alist '("\\._?xbhv\\'" . moos-mode))
+(add-to-list 'auto-mode-alist '("\\._?bhvx\\'" . moos-mode))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar moos-default-tab-width 2)

--- a/ivp/src/CMakeLists.txt
+++ b/ivp/src/CMakeLists.txt
@@ -180,6 +180,7 @@ SET(ROBOT_APPS
   pMarinePIDV22      uSimMarineV22       uSimMarineV23
   pMissionHash       pMissionEval        iBlinkStick
   pAutoPoke          uMayFinish          app_pluck
+  app_alognavr       app_nspatch
 )
 SET(IVP_NON_GUI_APPS
   app_alogsplit      app_alogsort        app_alogcheck

--- a/ivp/src/app_nspatch/BHVFile.cpp
+++ b/ivp/src/app_nspatch/BHVFile.cpp
@@ -1,0 +1,386 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: BHVFile.cpp                                          */
+/*    DATE: July 4th, 2025                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#include <cstdlib> 
+#include <cstdio> 
+#include <iostream> 
+#include "BHVFile.h"
+#include "MBUtils.h"
+
+using namespace std;
+
+//----------------------------------------------------------
+// Constructor()
+
+BHVFile::BHVFile()
+{
+  m_curr_block = "global";
+}
+
+//----------------------------------------------------------
+// Procedure: addLine()
+
+string BHVFile::addLine(string bhv, string line)
+{
+  bhv = stripBlankEnds(bhv);
+
+  // If we are going from global to local, make a note in the
+  // global lines. This serves the purpose of denoting where the
+  // block should reside in the expanded file. For now just mark
+  // it with new_block. Later when expanding, new_block will be
+  // replaced with all the lines for that app.  
+  if((m_curr_block == "global") && (bhv != "global")) {
+    m_blocks["global"].push_back("new_block_drx="+bhv);
+    m_curr_block = bhv;
+  }
+  else if(bhv == "global") 
+    m_curr_block = bhv;
+
+  m_blocks[bhv].push_back(line);
+
+  if(m_curr_block == "global")
+    return(bhv);
+
+#if 1
+  // =======================================================
+  // The super tricky hack: When we discover behavior name, 
+  // this is the unique key. For example BHV_Waypoint become
+  // BHV_Waypoint::transit. 
+  // A. Need to switch the key for mblocks[] mid-stream!
+  // B. Need to reachback:
+  //    new_block_drx=BHV_Waypoint
+  //    becomes
+  //    new_block_drx=BHV_Waypoint::transit
+  // =======================================================
+
+  string line_copy = tolower(stripBlankEnds(line));
+  string param = biteStringX(line_copy, '=');
+  string value = line_copy;
+  if(param == "name") {
+    if(!strContains(bhv, "@")) {
+      // Part A: Block replacement
+      // Part A1: Get a copy of map contents at old key
+      vector<string> old_block = m_blocks[bhv];
+      // Part A2: Remove contents at old key
+      m_blocks.erase(bhv);
+      // Part A3: Create the new key value
+      string full_bhv = bhv + "@" + value;
+      // Part A4: Store old contents at new key value
+      m_blocks[full_bhv] = old_block;
+      // Part A5: Adjust m_curr_block with new full_bhv
+      m_curr_block = full_bhv;
+
+      // Part B: Reachback to drx holder
+      unsigned int i, gsize = m_blocks["global"].size();
+      for(i=0; i<gsize; i++) {
+	if(m_blocks["global"][i] == ("new_block_drx="+bhv))
+	  m_blocks["global"][i] = ("new_block_drx="+full_bhv);
+      }
+      return(full_bhv);
+    }      
+  }
+#endif
+
+  return(bhv);
+}
+
+//----------------------------------------------------------
+// Procedure: applyBlock()
+
+void BHVFile::applyBlock(string bhv, vector<string> lines)
+{
+  if(m_blocks.count(bhv) == 0) {
+    m_blocks["global"].push_back("");    
+    m_blocks["global"].push_back("//----------------------------------");    
+    m_blocks["global"].push_back("new_block_drx="+bhv);
+  }
+
+  m_blocks[bhv] = lines;
+}
+
+//----------------------------------------------------------
+// Procedure: applyLine()
+//   Purpose: Take a line such as "speed = 2.5" and look for
+//            a line in given block that begins with "speed="
+//            and replace the line with the given line.
+
+void BHVFile::applyLine(string bhvname, string line)
+{
+  string lcopy = line;
+  string param = biteStringX(lcopy, '=');
+
+  bool applied = false;
+  
+  unsigned int vsize = m_blocks[bhvname].size();
+  for(unsigned int i=0; i<vsize; i++) {
+    string iline = m_blocks[bhvname][i];
+    string iline_param = biteStringX(iline, '=');
+    if(param == iline_param) {
+      string wpad = whitePad(m_blocks[bhvname][i]);
+      m_blocks[bhvname][i] = wpad + line;
+      applied = true;
+    }
+  }
+  // If this is a new line, just add it.
+  if(!applied)
+    m_blocks[bhvname].push_back(line);
+}
+
+//----------------------------------------------------------
+// Procedure: applyInitLine()
+//   Purpose: Take a line such as "initialize STATION=false" 
+//            or "STATION=false", and looks for a line in the 
+//            current cache of m_init_lines, and looks for a
+//            match, and replace the line with the given line,
+//            or, if not in current m_init_lines, add it.
+//      Note: The vector of m_init_lines is stored without the
+//            "initialize" in front.
+
+void BHVFile::applyInitLine(string init_line)
+{
+  // If the "initialize " begins the line, remove it.
+  if(strBegins(init_line, "initialize "))
+    biteStringX(init_line, ' ');
+
+  string init_line_copy = init_line;
+  string init_moos_var  = biteStringX(init_line_copy, '=');
+  
+  bool applied = false;
+
+  vector<string> new_init_lines;
+
+  for(unsigned int i=0; i<m_init_lines.size(); i++) {
+    string iline     = m_init_lines[i];
+    string imoos_var = biteStringX(iline, '=');
+    string imoos_val = iline;
+    if(imoos_var == init_moos_var) {
+      string newline = init_line;
+      new_init_lines.push_back(newline);
+      applied = true;
+    }
+    else
+      new_init_lines.push_back(m_init_lines[i]);
+  }
+  // If this is a new init line, just add it.
+  if(!applied)
+    new_init_lines.push_back(init_line);
+
+  // Final step: overwrite old init_lines vector with new vector
+  m_init_lines = new_init_lines;  
+}
+
+//----------------------------------------------------------
+// Procedure: applyModeLines()
+//   Purpose: If mode lines are applied, the whole new block,
+//            vector of strings, replaces the current block.
+
+void BHVFile::applyModeLines(vector<string> mode_lines)
+{
+  if(mode_lines.size() == 0)
+    return;
+  
+  m_mode_lines = mode_lines;
+}
+
+//----------------------------------------------------------
+// Procedure: addPatchLine()
+
+void BHVFile::addPatchLine(string bhv, string patch_line)
+{
+  m_patch_lines[bhv].push_back(patch_line);
+}
+
+//----------------------------------------------------------
+// Procedure: addInitLine()
+
+void BHVFile::addInitLine(string init_line)
+{
+  // Sanity check: Line must begin with "initialize "
+  if(!strBegins(init_line, "initialize "))
+    return;
+
+  // For convenience, remove the "initialize" and any white
+  // space between "initialize" and the MOOS variable.
+  biteStringX(init_line, ' ');
+  m_init_lines.push_back(init_line);
+}
+
+//----------------------------------------------------------
+// Procedure: addModeLine()
+
+void BHVFile::addModeLine(string mode_line)
+{
+  m_mode_lines.push_back(mode_line);
+}
+
+//----------------------------------------------------------
+// Procedure: getLines()
+
+vector<string> BHVFile::getLines()
+{
+  vector<string> vlines;
+
+  vector<string> lines;
+  if(m_blocks.count("global"))
+    lines = m_blocks.at("global");
+
+  bool inits_posted = false;
+  bool modes_posted = false;
+  
+  for(unsigned int i=0; i<lines.size(); i++) {
+    string line = lines[i];
+
+    if(!inits_posted && !strBegins(line, "//")) {
+      inits_posted = true;
+      vlines.push_back("");
+      for(unsigned int k=0; k<m_init_lines.size(); k++) {
+	string init_line = "initialize " + m_init_lines[k];
+	vlines.push_back(init_line);
+      }
+      continue;
+    }
+    
+    if(!modes_posted && !strBegins(line, "//")) {
+      modes_posted = true;
+      vlines.push_back("");
+      for(unsigned int k=0; k<m_mode_lines.size(); k++) 
+	vlines.push_back(m_mode_lines[k]);
+      continue;
+    }
+    
+    if(strBegins(line, "new_block_drx=")) {
+      string full_bhvname = rbiteString(line, '=');
+
+      string full_bhvname_copy = full_bhvname; 
+      
+      string short_bhvname = biteStringX(full_bhvname_copy, '@');
+
+      vlines.push_back("Behavior = " + short_bhvname);
+      
+      vector<string> blines = m_blocks[full_bhvname];
+      for(unsigned int j=0; j<blines.size(); j++) {
+	string bline = blines[j];
+	vlines.push_back(bline);
+      }
+      vlines.push_back("}");
+    }
+    // publishing at the global level
+    else {
+      line = findReplace(line, "Configuration", "Config");
+      vlines.push_back(line);
+    }    
+  }
+
+  return(vlines);
+}
+
+//----------------------------------------------------------
+// Procedure: applyToStemFile()
+
+BHVFile BHVFile::applyToStemFile(BHVFile stem_file)
+{
+  // To start with, the targ file is duplicate of stem file
+  BHVFile targ_file = stem_file;
+
+  // Apply init lines if any
+  for(unsigned int i=0; i<m_init_lines.size(); i++) {
+    targ_file.applyInitLine(m_init_lines[i]);
+  }
+
+  // Apply mode lines if any
+  if(m_mode_lines.size() != 0)
+    targ_file.applyModeLines(m_mode_lines);
+
+  
+  // Apply blocks if any
+  map<string, vector<string> >::iterator p;
+  for(p=m_blocks.begin(); p!=m_blocks.end(); p++) {
+    string bhvname = p->first;
+
+    vector<string> block = p->second;
+    if(bhvname != "global")
+      targ_file.applyBlock(bhvname, block);
+    else {
+      for(unsigned int i=0; i<block.size(); i++) {
+	string lblock = tolower(block[i]);
+	if(!strBegins(lblock, "behavior") &&
+	   !strBegins(lblock, "new_block_drx"))
+	  targ_file.applyLine("global", block[i]);
+      }
+    }
+  }
+    
+  // Apply patch lines if any
+  map<string, vector<string> >::iterator q;
+  for(q=m_patch_lines.begin(); q!=m_patch_lines.end(); q++) {
+    string bhv = q->first;
+    vector<string> patch_lines = q->second;
+    for(unsigned int i=0; i<patch_lines.size(); i++)
+    targ_file.applyLine(bhv, patch_lines[i]);
+  }
+
+  return(targ_file);
+}
+
+//----------------------------------------------------------
+// Procedure: whitePad()
+
+string BHVFile::whitePad(string str) 
+{
+  string wpad;
+  for(unsigned int i=0; i<str.length(); i++) {
+    if(str.at(i) != ' ')
+      return(wpad);
+    else
+      wpad += " ";
+  }
+  return(wpad);
+}
+
+//----------------------------------------------------------
+// Procedure: print()
+
+void BHVFile::print() 
+{
+  cout << "BhvFile:" << endl;
+  cout << "-------------------------------" << endl;
+  vector<string> lines = getLines();
+  for(unsigned int i=0; i<lines.size(); i++)
+    cout << lines[i] << endl;
+
+  //if(m_patch_lines.size() == 0)
+  //  return;
+  
+  cout << "PatchLines:" << endl;
+  cout << "-------------------------------" << endl;
+  map<string, vector<string> >::iterator p;
+  for(p=m_patch_lines.begin(); p!=m_patch_lines.end(); p++) {
+    string bhv = p->first;
+    vector<string> patches = p->second;
+    for(unsigned int i=0; i<patches.size(); i++) {
+      string patch = patches[i];
+      cout << bhv << "::" << patch << endl;
+    }
+  }
+}
+

--- a/ivp/src/app_nspatch/BHVFile.h
+++ b/ivp/src/app_nspatch/BHVFile.h
@@ -1,0 +1,76 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: BHVFile.h                                            */
+/*    DATE: July 24th, 2025                                      */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+ 
+#ifndef BHV_FILE_HEADER
+#define BHV_FILE_HEADER
+
+#include <string>
+#include <vector>
+#include <map>
+
+class BHVFile {
+public:
+  BHVFile();
+  virtual ~BHVFile() {};
+
+public: // building from input file
+  std::string addLine(std::string bhvname, std::string line);
+
+  void addPatchLine(std::string bhvname, std::string patch_line);
+  void addInitLine(std::string init_line);
+  void addModeLine(std::string mode_line);
+
+public: // applying patches
+  void applyBlock(std::string bhvname, std::vector<std::string>);
+  void applyLine(std::string bhvname, std::string line);
+  void applyInitLine(std::string init_line);
+  void applyModeLines(std::vector<std::string> mode_lines);
+
+  BHVFile applyToStemFile(BHVFile);
+
+public: // getters
+  std::vector<std::string> getLines();
+
+  void print();
+
+protected: // utility
+  std::string whitePad(std::string);
+  
+ protected: 
+
+  std::string m_curr_block;
+  
+  // Ordered vector of "initialize MOOSVar=value" lines
+  std::vector<std::string> m_init_lines;
+
+  // Ordered vector of "mode" lines
+  std::vector<std::string> m_mode_lines;
+
+  // Keyed on bhvname, or "global" for global params
+  std::map<std::string, std::vector<std::string> > m_blocks;
+
+  // Keyed on bhvname, or "global" for global params
+  std::map<std::string, std::vector<std::string> > m_patch_lines;
+};
+
+#endif

--- a/ivp/src/app_nspatch/CMakeLists.txt
+++ b/ivp/src/app_nspatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 #--------------------------------------------------------
-# The CMakeLists.txt for:                      app_nsplug
+# The CMakeLists.txt for:                         nspatch
 # Author(s):                                Mike Benjamin
 #--------------------------------------------------------
 
@@ -7,14 +7,16 @@
 SET(SYSTEM_LIBS m)
 
 SET(SRC
-   Expander.cpp
-   Expander_Info.cpp
-   main.cpp
-)
- 
-ADD_EXECUTABLE(nsplug ${SRC})
-     
-TARGET_LINK_LIBRARIES(nsplug
+  BHVFile.cpp
+  MOOSFile.cpp
+  Populator_BHVFile.cpp
+  Populator_MOOSFile.cpp
+  main.cpp
+  PatchApplicator.cpp)
+
+ADD_EXECUTABLE(nspatch ${SRC})
+   
+TARGET_LINK_LIBRARIES(nspatch
   mbutil
   ${SYSTEM_LIBS})
 

--- a/ivp/src/app_nspatch/MOOSFile.cpp
+++ b/ivp/src/app_nspatch/MOOSFile.cpp
@@ -1,0 +1,267 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: MOOSFile.cpp                                   */
+/*    DATE: May 7th, 2025                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#include <cstdlib> 
+#include <cstdio> 
+#include <iostream> 
+#include "MOOSFile.h"
+#include "MBUtils.h"
+
+using namespace std;
+
+//----------------------------------------------------------
+// Constructor()
+
+MOOSFile::MOOSFile()
+{
+  m_curr_block = "global";
+}
+
+//----------------------------------------------------------
+// Procedure: addLine()
+//      Note: app may be a MOOSApp name or "global"
+
+void MOOSFile::addLine(string app, string line)
+{
+  app = stripBlankEnds(app);
+
+  // If we are going from global to local, make a note in the
+  // global lines. This serves the purpose of denoting where the
+  // block should reside in the expanded file. For now just mark
+  // it with new_block. Later when expanding, new_block will be
+  // replaced with all the lines for that app.  
+  if((m_curr_block == "global") && (app != "global")) {
+    m_blocks["global"].push_back("new_block_drx=" + app);
+    m_curr_block = app;
+  }
+  else if(app == "global") 
+    m_curr_block = app;
+
+  m_blocks[app].push_back(line);
+}
+
+//----------------------------------------------------------
+// Procedure: applyBlock()
+
+void MOOSFile::applyBlock(string app, vector<string> lines)
+{
+  if(m_blocks.count(app) == 0) {
+    m_blocks["global"].push_back("");    
+    m_blocks["global"].push_back("//----------------------------------");    
+    m_blocks["global"].push_back("// " + app + " Config Block");    
+    m_blocks["global"].push_back("");    
+    m_blocks["global"].push_back("new_block_drx="+app);
+  }
+  
+  m_blocks[app] = lines;
+}
+
+//----------------------------------------------------------
+// Procedure: applyLine()
+//   Purpose: Take a line such as "speed = 2.5" and look for
+//            a line in the give block that begins with "speed="
+//            and replace the line with the given line.
+
+void MOOSFile::applyLine(string app, string line)
+{
+  string line_copy = line;
+  string line_param;
+  if(app != "ANTLER")
+    line_param = biteStringX(line_copy, '=');
+  else
+    line_param = removeWhite(biteStringX(line_copy, '@'));
+  
+  bool applied = false;
+  
+  unsigned int vsize = m_blocks[app].size();
+  for(unsigned int i=0; i<vsize; i++) {
+    string iline = m_blocks[app][i];
+    string iline_param;
+    if(app != "ANTLER")
+      iline_param = biteStringX(iline, '=');
+    else
+      iline_param = removeWhite(biteStringX(iline, '@'));
+
+    if(line_param == iline_param) {
+      string wpad = whitePad(m_blocks[app][i]);
+      m_blocks[app][i] = wpad + line;
+      applied = true;
+    }
+  }
+  // If this is a new line, just add it.
+  if(!applied) 
+    m_blocks[app].push_back(line);
+}
+
+//----------------------------------------------------------
+// Procedure: addPatchLine()
+
+void MOOSFile::addPatchLine(string app, string patch_line)
+{
+  m_patch_lines[app].push_back(patch_line);
+}
+
+//----------------------------------------------------------
+// Procedure: getLines()
+
+vector<string> MOOSFile::getLines()
+{
+  vector<string> vlines;
+
+  vector<string> lines;
+  if(m_blocks.count("global"))
+    lines = m_blocks.at("global");
+
+  for(unsigned int i=0; i<lines.size(); i++) {
+    string line = lines[i];
+    if(strBegins(line, "new_block_drx=")) {
+      string app = rbiteString(line, '=');
+      vlines.push_back("ProcessConfig = " + app);
+      
+      vector<string> blines = m_blocks[app];
+      for(unsigned int j=0; j<blines.size(); j++) {
+	string bline = blines[j];
+	vlines.push_back(bline);
+      }
+      vlines.push_back("}");
+    }
+    // publishing at the global level
+    else {
+      line = findReplace(line, "config", "Config");
+      line = findReplace(line, "block", "Block");
+      line = findReplace(line, "Configuration", "Config");
+      vlines.push_back(line);
+    }    
+  }
+
+  return(vlines);
+}
+
+//----------------------------------------------------------
+// Procedure: applyToStemFile()
+
+MOOSFile MOOSFile::applyToStemFile(MOOSFile stem_file)
+{
+  // To start with, the targ file is duplicate of stem file
+  MOOSFile targ_file = stem_file;
+
+  // Apply blocks if any
+  map<string, vector<string> >::iterator p;
+  for(p=m_blocks.begin(); p!=m_blocks.end(); p++) {
+    string app = p->first;
+
+    vector<string> block = p->second;
+    if(app != "global")
+      targ_file.applyBlock(app, block);
+    else {
+      for(unsigned int i=0; i<block.size(); i++) {
+	string lblock = tolower(block[i]);
+	if(!strBegins(lblock, "processconfig") &&
+	   !strBegins(lblock, "new_block_drx"))
+	  targ_file.applyLine("global", block[i]);
+      }
+    }
+  }
+    
+  // Apply patch lines if any
+  map<string, vector<string> >::iterator q;
+  for(q=m_patch_lines.begin(); q!=m_patch_lines.end(); q++) {
+    string appname = q->first;
+    vector<string> patch_lines = q->second;
+    for(unsigned int i=0; i<patch_lines.size(); i++)
+      targ_file.applyLine(appname, patch_lines[i]);
+  }
+
+  return(targ_file);
+}
+
+//----------------------------------------------------------
+// Procedure: whitePad()
+
+string MOOSFile::whitePad(string str) 
+{
+  string wpad;
+  for(unsigned int i=0; i<str.length(); i++) {
+    if(str.at(i) != ' ')
+      return(wpad);
+    else
+      wpad += " ";
+  }
+  return(wpad);
+}
+
+//----------------------------------------------------------
+// Procedure: print()
+
+void MOOSFile::print() 
+{
+  cout << "MoosFile:" << endl;
+  cout << "-------------------------------" << endl;
+  vector<string> lines = getLines();
+  for(unsigned int i=0; i<lines.size(); i++)
+    cout << lines[i] << endl;
+
+  //if(m_patch_lines.size() == 0)
+  //  return;
+  
+  cout << "PatchLines:" << endl;
+  cout << "-------------------------------" << endl;
+  map<string, vector<string> >::iterator p;
+  for(p=m_patch_lines.begin(); p!=m_patch_lines.end(); p++) {
+    string app = p->first;
+    vector<string> patches = p->second;
+    for(unsigned int i=0; i<patches.size(); i++) {
+      string patch = patches[i];
+      cout << app << "::" << patch << endl;
+    }
+  }
+}
+
+//----------------------------------------------------------
+// Procedure: print2()
+
+void MOOSFile::print2() 
+{
+  cout << "MoosFile Print2:" << endl;
+  cout << "-------------------------------" << endl;
+
+  map<string, vector<string> >::iterator p1;
+  for(p1=m_blocks.begin(); p1!=m_blocks.end(); p1++) {
+    string app = p1->first;
+    vector<string> lines = p1->second;
+    cout << "app:" << app << ", size:" << lines.size() << endl;
+  }
+  
+  cout << "PatchLines Print2:" << endl;
+  cout << "-------------------------------" << endl;
+  map<string, vector<string> >::iterator p;
+  for(p=m_patch_lines.begin(); p!=m_patch_lines.end(); p++) {
+    string app = p->first;
+    vector<string> patches = p->second;
+    for(unsigned int i=0; i<patches.size(); i++) {
+      string patch = patches[i];
+      cout << app << "::" << patch << endl;
+    }
+  }
+}
+

--- a/ivp/src/app_nspatch/MOOSFile.h
+++ b/ivp/src/app_nspatch/MOOSFile.h
@@ -1,0 +1,66 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: MissionFile.h                                        */
+/*    DATE: May 7th, 2025                                        */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+ 
+#ifndef MOOS_FILE_HEADER
+#define MOOS_FILE_HEADER
+
+#include <string>
+#include <vector>
+#include <map>
+
+class MOOSFile {
+public:
+  MOOSFile();
+  virtual ~MOOSFile() {};
+
+public: // building from input file
+  void addLine(std::string app, std::string line);
+  void addPatchLine(std::string app, std::string patch_line);
+
+public: // applying patches
+  void applyBlock(std::string app, std::vector<std::string>);
+  void applyLine(std::string app, std::string line);
+
+  MOOSFile applyToStemFile(MOOSFile);
+
+public: // getters
+  std::vector<std::string> getLines();
+
+  void print();
+  void print2();
+
+protected: // utility
+  std::string whitePad(std::string);
+  
+ protected: 
+
+  std::string m_curr_block;
+  
+  // Keyed on appname, or "global" for global params
+  std::map<std::string, std::vector<std::string> > m_blocks;
+
+  // Keyed on appname, or "global" for global params
+  std::map<std::string, std::vector<std::string> > m_patch_lines;
+};
+
+#endif

--- a/ivp/src/app_nspatch/PatchApplicator.cpp
+++ b/ivp/src/app_nspatch/PatchApplicator.cpp
@@ -1,0 +1,244 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: PatchApplicator.cpp                                  */
+/*    DATE: July 4th, 2025                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <iostream>
+#include "TermUtils.h"
+#include "MBUtils.h"
+#include "Populator_MOOSFile.h"
+#include "Populator_BHVFile.h"
+#include "PatchApplicator.h"
+
+using namespace std;
+
+//--------------------------------------------------------
+// Constructor()
+
+PatchApplicator::PatchApplicator()
+{
+  m_verbose = false;
+}
+
+//--------------------------------------------------------
+// Procedure: applyPatch()
+
+bool PatchApplicator::applyPatch()
+{
+  bool moos_ok = false;
+  bool bhv_ok  = false;
+
+  if(m_verbose)
+    printConfig();
+  
+  if((m_files_xmoos.size() != 0) &&
+     (m_file_stem_moos != "") &&
+     (m_file_targ_moos != "")) 
+    moos_ok = applyPatchMoos();
+  
+  if((m_files_xbhv.size() != 0) &&
+     (m_file_stem_bhv != "") &&
+     (m_file_targ_bhv != ""))
+    bhv_ok = applyPatchBhv();
+
+  return(moos_ok || bhv_ok);
+}
+
+//--------------------------------------------------------
+// Procedure: applyPatchMoos()
+
+bool PatchApplicator::applyPatchMoos()
+{
+  // =====================================================
+  // Part 1: Populate the MOOSFile constituting the patch
+  // =====================================================
+  Populator_MOOSFile pop_xfile(m_verbose);
+  for(unsigned int i=0; i<m_files_xmoos.size(); i++)
+    pop_xfile.addFileMOOS(m_files_xmoos[i]);
+  bool ok1 = pop_xfile.populate();
+  if(!ok1)
+    return(false);
+  MOOSFile xfile = pop_xfile.getMOOSFile();
+  
+  // =====================================================
+  // Part 2: Populate the MOOSFile constituting the stem
+  // =====================================================
+  Populator_MOOSFile pop_stem_file(m_verbose);
+  pop_stem_file.setFileMOOS(m_file_stem_moos);
+  bool ok2 = pop_stem_file.populate();
+  if(!ok2)
+    return(false);
+  MOOSFile stem_file = pop_stem_file.getMOOSFile();
+
+  // =====================================================
+  // Part 3: Apply the patch file to the stem file
+  // =====================================================
+  MOOSFile targ_file = xfile.applyToStemFile(stem_file);
+
+  // =====================================================
+  // Part 4: Write the targ MOOSFile to the targ file.
+  // =====================================================
+  vector<string> lines = targ_file.getLines();
+
+  FILE *f = fopen(m_file_targ_moos.c_str(), "w");
+  for(unsigned int i=0; i<lines.size(); i++) {
+    fprintf(f, "%s\n", lines[i].c_str());
+  }
+  
+  return(true);
+}
+
+//--------------------------------------------------------
+// Procedure: applyPatchBhv()
+
+bool PatchApplicator::applyPatchBhv()
+{
+  // =====================================================
+  // Part 1: Populate the BHVFile constituting the patch
+  // =====================================================
+  Populator_BHVFile pop_xfile(m_verbose);
+  for(unsigned int i=0; i<m_files_xbhv.size(); i++)
+    pop_xfile.addFileBHV(m_files_xbhv[i]);
+  bool ok1 = pop_xfile.populate();
+  if(!ok1)
+    return(false);
+  BHVFile xfile = pop_xfile.getBHVFile();
+  
+  // =====================================================
+  // Part 2: Populate the BHVFile constituting the stem
+  // =====================================================
+  Populator_BHVFile pop_stem_file(m_verbose);
+  pop_stem_file.setFileBHV(m_file_stem_bhv);
+  bool ok2 = pop_stem_file.populate();
+  if(!ok2)
+    return(false);
+  BHVFile stem_file = pop_stem_file.getBHVFile();
+
+  // =====================================================
+  // Part 3: Apply the patch file to the stem file
+  // =====================================================
+  BHVFile targ_file = xfile.applyToStemFile(stem_file);
+
+  // =====================================================
+  // Part 4: Write the targ BHVFile to the targ file.
+  // =====================================================
+  vector<string> lines = targ_file.getLines();
+
+  FILE *f = fopen(m_file_targ_bhv.c_str(), "w");
+  for(unsigned int i=0; i<lines.size(); i++) 
+    fprintf(f, "%s\n", lines[i].c_str());
+  
+  return(true);
+}
+
+//--------------------------------------------------------
+// Procedure: addXMoosFile()
+
+bool PatchApplicator::addXMoosFile(string fstr)
+{
+  if(!okFileToRead(fstr))
+    return(false);
+
+  m_files_xmoos.push_back(fstr);
+  return(true);  
+}
+
+//--------------------------------------------------------
+// Procedure: setStemMoosFile()
+
+bool PatchApplicator::setStemMoosFile(string fstr)
+{
+  if(!okFileToRead(fstr))
+    return(false);
+  
+  m_file_stem_moos = fstr;
+  return(true);  
+}
+
+//--------------------------------------------------------
+// Procedure: setTargMoosFile()
+
+bool PatchApplicator::setTargMoosFile(string fstr)
+{
+  if(!okFileToWrite(fstr))
+    return(false);
+  
+  m_file_targ_moos = fstr;
+  return(true);  
+}
+
+//--------------------------------------------------------
+// Procedure: addXBhvFile()
+
+bool PatchApplicator::addXBhvFile(string fstr)
+{
+  if(!okFileToRead(fstr))
+    return(false);
+
+  m_files_xbhv.push_back(fstr);
+  return(true);  
+}
+
+//--------------------------------------------------------
+// Procedure: setStemBhvFile()
+
+bool PatchApplicator::setStemBhvFile(string fstr)
+{
+  if(!okFileToRead(fstr))
+    return(false);
+  
+  m_file_stem_bhv = fstr;
+  return(true);  
+}
+
+//--------------------------------------------------------
+// Procedure: setTargBhvFile()
+
+bool PatchApplicator::setTargBhvFile(string fstr)
+{
+  if(!okFileToWrite(fstr))
+    return(false);
+  
+  m_file_targ_bhv = fstr;
+  return(true);  
+}
+
+//--------------------------------------------------------
+// Procedure: printConfig()
+
+void PatchApplicator::printConfig()
+{
+  cout << "appplyPatchMOOS(): " << endl;
+  cout << "  stem: " << m_file_stem_moos << endl;
+  for(unsigned int i=0; i<m_files_xmoos.size(); i++) 
+    cout << "  patch: " << m_files_xmoos[i] << endl;
+  cout << "  targ: " << m_file_targ_moos << endl;
+
+  cout << "appplyPatchBHV(): " << endl;
+  cout << "  stem: " << m_file_stem_bhv << endl;
+  for(unsigned int i=0; i<m_files_xbhv.size(); i++) 
+    cout << "  patch: " << m_files_xbhv[i] << endl;
+  cout << "  targ: " << m_file_targ_bhv << endl;
+  
+}

--- a/ivp/src/app_nspatch/PatchApplicator.h
+++ b/ivp/src/app_nspatch/PatchApplicator.h
@@ -1,0 +1,65 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: PatchApplicator.h                                    */
+/*    DATE: July 4th, 2025                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#ifndef PATCH_APPLICATOR_HEADER
+#define PATCH_APPLICATOR_HEADER
+
+#include <vector>
+#include <string>
+
+class PatchApplicator
+{
+ public:
+  PatchApplicator();
+  ~PatchApplicator() {}
+
+  bool addXMoosFile(std::string); // patch file
+  bool setStemMoosFile(std::string);
+  bool setTargMoosFile(std::string);
+  
+  bool addXBhvFile(std::string); // patch file
+  bool setStemBhvFile(std::string);
+  bool setTargBhvFile(std::string);
+  
+  bool applyPatch();
+  void setVerbose() {m_verbose=true;}
+  
+ protected:
+  bool applyPatchMoos();
+  bool applyPatchBhv();
+  void printConfig();
+  
+ private:
+  std::vector<std::string> m_files_xmoos; //patch files
+  std::string              m_file_stem_moos;
+  std::string              m_file_targ_moos;
+
+  std::vector<std::string> m_files_xbhv; // patch files
+  std::string              m_file_stem_bhv;
+  std::string              m_file_targ_bhv;
+
+  bool m_verbose;
+};
+
+#endif 
+

--- a/ivp/src/app_nspatch/Populator_BHVFile.cpp
+++ b/ivp/src/app_nspatch/Populator_BHVFile.cpp
@@ -1,0 +1,145 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: Populator_BHVFile.cpp                                */
+/*    DATE: July 4th, 2025                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#include <cstdlib>
+#include <iostream>
+#include "FileBuffer.h" 
+#include "Populator_BHVFile.h"
+#include "MBUtils.h"
+
+using namespace std;
+
+//----------------------------------------------------------
+// Constructor()
+
+Populator_BHVFile::Populator_BHVFile(bool verbose)
+{
+  m_verbose = verbose;
+}
+
+//----------------------------------------------------------
+// Procedure: setFileBHV()
+
+bool Populator_BHVFile::setFileBHV(string filename) 
+{
+  m_files_bhv.clear();
+  return(addFileBHV(filename));
+}
+
+//----------------------------------------------------------
+// Procedure: addFileBHV()
+
+bool Populator_BHVFile::addFileBHV(string filename) 
+{
+  if(!okFileToRead(filename))
+    return(false);
+  
+  m_files_bhv.push_back(filename);
+  return(true);
+}
+
+//----------------------------------------------------------
+// Procedure: populate()
+
+bool Populator_BHVFile::populate() 
+{
+  bool all_ok = true;
+  for(unsigned int i=0; i<m_files_bhv.size(); i++)
+    all_ok = all_ok && populate(m_files_bhv[i]);
+
+  return(all_ok);
+}
+
+//----------------------------------------------------------
+// Procedure: populate(filename)
+
+bool Populator_BHVFile::populate(string file_bhv)
+{
+  if(m_verbose)
+    cout << "Looking for: " << file_bhv << endl;
+
+  // =======================================================
+  // Part 1A: Find and Read the .bhv file
+  vector<string> lines = fileBuffer(file_bhv);
+  if(lines.size() == 0) {
+    cout << "Not found or empty file: " << file_bhv << endl;
+    return(false);
+  }
+
+  string curr_block = "global";
+  
+  for(unsigned int i=0; i<lines.size(); i++) {
+    string line = lines[i];
+    string lcopy = stripBlankEnds(line);
+
+    if(curr_block == "global") {
+
+      if(strBegins(tolower(lcopy), "behavior")) {
+	curr_block = rbiteString(lcopy, '=');
+	continue;
+      }
+      if(strContains(lcopy, "::")) {
+	string bhv = nibbleString(lcopy, "::");
+	string pair = lcopy;
+	m_bhv_file.addPatchLine(bhv, pair);
+	continue;
+      }
+      
+      if(strBegins(lcopy, "initialize")) {
+	m_bhv_file.addInitLine(lcopy);
+	continue;
+      }      
+
+      if(strBegins(lcopy, "set") && strContains(lcopy, "MODE")) {
+	m_bhv_file.addModeLine(line);
+	curr_block = "modes";
+	continue;
+      }
+
+      m_bhv_file.addLine("global", line);
+      continue;
+    }
+
+    if((strBegins(lcopy, "}")) && (curr_block == "modes")) {
+      m_bhv_file.addModeLine(line);
+      curr_block = "global";
+      continue;
+    }
+
+    if(lcopy == "}") {
+      //m_bhv_file.addLine(curr_block, line);
+      curr_block = "global";
+      continue;
+    }
+
+    if(curr_block == "modes") {
+      m_bhv_file.addModeLine(line);
+      continue;
+    }
+    
+    curr_block = m_bhv_file.addLine(curr_block, line);
+  }
+
+  return(true);
+}
+

--- a/ivp/src/app_nspatch/Populator_BHVFile.h
+++ b/ivp/src/app_nspatch/Populator_BHVFile.h
@@ -1,0 +1,60 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: Populator_BHVFile.h                                 */
+/*    DATE: July 4th, 2025                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+ 
+#ifndef POPULATOR_BHV_FILE_HEADER
+#define POPULATOR_BHV_FILE_HEADER
+
+#include <string>
+#include "BHVFile.h"
+
+class Populator_BHVFile {
+public:
+  Populator_BHVFile(bool verbose=false);
+  virtual ~Populator_BHVFile() {};
+
+  void setVerbose(bool v=true)  {m_verbose=v;}
+
+  bool setFileBHV(std::string filename);
+  bool addFileBHV(std::string filename);
+  
+  bool populate();
+
+  BHVFile getBHVFile() {return(m_bhv_file);};
+
+protected:
+  bool populate(std::string filename);
+
+
+  
+ protected:
+  BHVFile  m_bhv_file;
+
+protected: // config vars
+  
+  bool m_verbose;
+
+  std::vector<std::string> m_files_bhv;
+};
+
+#endif
+

--- a/ivp/src/app_nspatch/Populator_MOOSFile.cpp
+++ b/ivp/src/app_nspatch/Populator_MOOSFile.cpp
@@ -1,0 +1,129 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: Populator_MOOSFile.cpp                               */
+/*    DATE: May 7th, 2025                                        */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#include <cstdlib>
+#include <iostream>
+#include "FileBuffer.h" 
+#include "Populator_MOOSFile.h"
+#include "MBUtils.h"
+
+using namespace std;
+
+//----------------------------------------------------------
+// Constructor()
+
+Populator_MOOSFile::Populator_MOOSFile(bool verbose)
+{
+  m_verbose = verbose;
+}
+
+//----------------------------------------------------------
+// Procedure: setFileMOOS()
+
+bool Populator_MOOSFile::setFileMOOS(string filename) 
+{
+  m_files_moos.clear();
+  return(addFileMOOS(filename));
+}
+
+//----------------------------------------------------------
+// Procedure: addFileMOOS()
+
+bool Populator_MOOSFile::addFileMOOS(string filename) 
+{
+  if(!okFileToRead(filename))
+    return(false);
+  
+  m_files_moos.push_back(filename);
+  return(true);
+}
+
+//----------------------------------------------------------
+// Procedure: populate()
+
+bool Populator_MOOSFile::populate() 
+{
+  bool all_ok = true;
+  for(unsigned int i=0; i<m_files_moos.size(); i++)
+    all_ok = all_ok && populate(m_files_moos[i]);
+
+  return(all_ok);
+}
+
+//----------------------------------------------------------
+// Procedure: populate(filename)
+
+bool Populator_MOOSFile::populate(string file_moos)
+{
+  if(m_verbose)
+    cout << "Looking for: " << file_moos << endl;
+
+  // =======================================================
+  // Part 1A: Find and Read the .moos file
+  vector<string> lines = fileBuffer(file_moos);
+  if(lines.size() == 0) {
+    cout << "Not found or empty file: " << file_moos << endl;
+    return(false);
+  }
+
+  string curr_block = "global";
+  
+  for(unsigned int i=0; i<lines.size(); i++) {
+    string line = lines[i];
+    string line_copy = stripBlankEnds(line);
+
+    if(curr_block == "global") {
+
+      if(strBegins(tolower(line_copy), "processconfig")) {
+	curr_block = rbiteString(line_copy, '=');
+	continue;
+      }
+      if(strContains(line_copy, "::")) {
+	string app = nibbleString(line_copy, "::");
+	string pair = line_copy;
+	m_moos_file.addPatchLine(app, pair);
+	continue;
+      }
+      m_moos_file.addLine("global", line);
+      continue;
+    }
+
+    if(line_copy == "}") {
+      //m_moos_file.addLine(curr_block, line);
+      curr_block = "global";
+      continue;
+    }
+
+    m_moos_file.addLine(curr_block, line);
+  
+  }
+
+  if(m_verbose) {
+    cout << "MOOSFile: " << file_moos << endl;
+    cout << "-----------------------" << endl;
+    m_moos_file.print();
+  }
+  
+  return(true);
+}
+

--- a/ivp/src/app_nspatch/Populator_MOOSFile.h
+++ b/ivp/src/app_nspatch/Populator_MOOSFile.h
@@ -1,0 +1,58 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: Populator_MOOSFile.h                                 */
+/*    DATE: May 7th, 2025                                        */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+ 
+#ifndef POPULATOR_MOOS_FILE_HEADER
+#define POPULATOR_MOOS_FILE_HEADER
+
+#include <string>
+#include "MOOSFile.h"
+
+class Populator_MOOSFile {
+public:
+  Populator_MOOSFile(bool verbose=false);
+  virtual ~Populator_MOOSFile() {};
+
+  void setVerbose(bool v=true)  {m_verbose=v;}
+
+  bool setFileMOOS(std::string filename);
+  bool addFileMOOS(std::string filename);
+  
+  bool populate();
+
+  MOOSFile getMOOSFile() {return(m_moos_file);};
+
+protected:
+  bool populate(std::string filename);
+  
+ protected:
+  MOOSFile    m_moos_file;
+
+protected: // config vars
+  
+  bool m_verbose;
+
+  std::vector<std::string> m_files_moos;
+};
+
+#endif
+

--- a/ivp/src/app_nspatch/main.cpp
+++ b/ivp/src/app_nspatch/main.cpp
@@ -1,0 +1,133 @@
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Eng, MIT Cambridge MA             */
+/*    FILE: main.cpp                                             */
+/*    DATE: May 7th, 2025                                        */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#include <cstdlib>
+#include <iostream>
+#include "MBUtils.h"
+#include "ReleaseInfo.h"
+#include "Populator_MOOSFile.h"
+#include "PatchApplicator.h"
+
+using namespace std;
+
+void showHelpAndExit();
+
+//--------------------------------------------------------
+// Procedure: main()
+
+int main(int argc, char *argv[])
+{
+  PatchApplicator papp;
+
+  bool handled = true;
+  for(int i=1; i<argc; i++) {
+    string argi = argv[i];
+    if((argi=="-h") || (argi == "--help") || (argi=="-help"))
+      showHelpAndExit();
+    else if((argi=="--version") || (argi=="-version")) {
+      showReleaseInfo("nspatch", "gpl");
+      return(0);
+    }
+    else if((argi=="--verbose") || (argi == "-v"))
+      papp.setVerbose();
+
+    else if(strEnds(argi, ".xmoos"))
+      papp.addXMoosFile(argi);
+
+    else if(strEnds(argi, ".xbhv"))
+      papp.addXBhvFile(argi);
+
+    else if(strBegins(argi, "--stem=")) {
+      string stem_file = argi.substr(7);
+      if(strEnds(stem_file, ".moos"))
+	papp.setStemMoosFile(stem_file);
+      else if(strEnds(stem_file, ".bhv"))
+	papp.setStemBhvFile(stem_file);
+    }
+      
+    else if(strBegins(argi, "--targ=")) {
+      string targ_file = argi.substr(7);
+      if(strEnds(targ_file, ".moos") ||
+	 strEnds(targ_file, ".moosx"))
+	papp.setTargMoosFile(targ_file);
+      else if(strEnds(targ_file, ".bhv") ||
+	      strEnds(targ_file, ".bhvx"))
+	papp.setTargBhvFile(targ_file);
+    }
+      
+    if(!handled) {
+      cout << "Unhandled command line argument: " << argi << endl;
+      cout << "Use --help for usage. Exiting.   " << endl;
+      exit(1);
+    }
+  }
+    
+  papp.applyPatch();
+
+  return(0);
+}
+
+//------------------------------------------------------------
+// Procedure: showHelpAndExit()
+
+void showHelpAndExit()
+{
+  cout << "Usage: " << endl;
+  cout << "  nspatch stem_file patch_file targ_file [OPTIONS]          " << endl;
+  cout << "                                                            " << endl;
+  cout << "Synopsis:                                                   " << endl;
+  cout << "  Apply a given patch file to a given stem file, to make a  " << endl;
+  cout << "  new target file. Supported file types are mission (.moos) " << endl;
+  cout << "  files or behavior (.bhv) files. The objective is to make a" << endl;
+  cout << "  new mission from an existing (stem) mission by providing  " << endl;
+  cout << "  the patch file (difference) applied to overwrite or       " << endl;
+  cout << "  augment portions of the stem mission.                     " << endl;
+  cout << "                                                            " << endl;
+  cout << "  Mandatory arguments: a stem file, one or more patch files " << endl;
+  cout << "  and a target file. nspatch will work with either MOOS or  " << endl;
+  cout << "  behavior files, but not both, in any given invocation.    " << endl;
+  cout << "                                                            " << endl;
+  cout << "  Note: Files ending in .xmoos are interpreted to be patch  " << endl;
+  cout << "        files in .moos format. Files ending in .xbhv are    " << endl;
+  cout << "        interpreted to be behavior files.                   " << endl;
+  cout << "                                                            " << endl;
+  cout << "Options:                                                    " << endl;
+  cout << "  -h,--help       Displays this help message                " << endl;
+  cout << "  -v,--version    Display current release version           " << endl;
+  cout << "  --verbose       Write verbose output.                     " << endl;
+  cout << "                                                            " << endl;
+  cout << "  --stem=stem.moos  Stem moos or behavior file              " << endl;
+  cout << "  --targ=targ.moos  Target moos or behavior file            " << endl;
+  cout << "                                                            " << endl;
+  cout << "Returns:                                                    " << endl;
+  cout << "  0 if ok                                                   " << endl;
+  cout << "  1 if not ok                                               " << endl;
+  cout << "                                                            " << endl;
+  cout << "Further Notes:                                              " << endl;
+  cout << "  (1) The order of arguments is irrelevent.                 " << endl;
+  cout << "Examples:                                                   " << endl;
+  cout << "  $ nspatch --stem=stem.moos patch.xmoos --targ=targ.moosx  " << endl;
+  cout << "  $ nspatch --stem=stem.bhv patch.xbhv --targ=targ.bhvx     " << endl;
+  cout << endl;
+  exit(0);
+}

--- a/ivp/src/app_nsplug/Expander.cpp
+++ b/ivp/src/app_nsplug/Expander.cpp
@@ -53,6 +53,8 @@ Expander::Expander(string given_infile, string given_outfile)
 
   m_interactive = false;
   m_impatient = false;
+
+  m_xfile = false;
 }
 
 //--------------------------------------------------------
@@ -93,8 +95,19 @@ vector<string> Expander::expandFile(string filename,
   vector<string> return_vector;
   vector<string> empty_vector;
 
-  vector<string> fvector = fileBuffer(filename);
+  vector<string> fvector;
+  // If xfile is true, first try the input file, with an 'x' at end.
+  // For example, meta_shoreside.moosx instead of meta_shoreside.moos
+  if(m_xfile) {
+    cout << "Looking for:" << filename <<"x" << endl;
+    fvector = fileBuffer(filename + "x");
+  }
 
+  if(!m_xfile || (fvector.size() == 0))
+    fvector = fileBuffer(filename);
+
+  m_xfile = false; // Only use xfile at topmost level
+  
   unsigned int i, vsize = fvector.size();
   if(vsize == 0) {
     cout << "#  Warning: The file " << filename << " was empty." << endl;    

--- a/ivp/src/app_nsplug/Expander.h
+++ b/ivp/src/app_nsplug/Expander.h
@@ -50,7 +50,8 @@ class Expander
   void setPartialsOK(bool v) {m_partial_expand_ok=v;}
   void setTerminal(bool v)   {m_terminal=v;}
   void setInteractive(bool v) {m_interactive=v;}
-  void setImpatient(bool v)   {m_impatient=v;}
+  void setImpatient(bool v)  {m_impatient=v;}
+  void setXFile(bool v)      {m_xfile=v;}
   void addPath(std::string);
 
  protected:
@@ -108,6 +109,8 @@ class Expander
 
   bool m_interactive;
   bool m_impatient;
+
+  bool m_xfile;
 };
 
 #endif 

--- a/ivp/src/app_nsplug/Expander_Info.cpp
+++ b/ivp/src/app_nsplug/Expander_Info.cpp
@@ -56,6 +56,10 @@ void showHelpAndExit()
   blk("Options:                                                        ");
   mag("  --help, -h                                                    ");
   blk("      Display this help message.                                ");
+  mag("  --xfile,-x                                                    ");
+  blk("      In reading the input file, check first if the filename    ");
+  blk("      appended with x exists. If so, use that instead. Example: ");
+  blk("      Use meta_vehicle.moosx instead of meta_vehicle.moos       ");
   mag("  --force,-f                                                    ");
   blk("      Overwrite the output file even if it already exists.      ");
   blk("      The user will not be prompted for confirmation.           ");

--- a/ivp/src/app_nsplug/main.cpp
+++ b/ivp/src/app_nsplug/main.cpp
@@ -23,7 +23,6 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <string>
 #include <iostream>
 #include "ColorParse.h"
@@ -34,10 +33,8 @@
 
 using namespace std;
 
-void showHelpAndExit();
-
 //--------------------------------------------------------
-// Procedure: main
+// Procedure: main()
 
 int main(int argc, char *argv[])
 {
@@ -57,6 +54,8 @@ int main(int argc, char *argv[])
       showManualAndExit();
     else if((arg == "-f") || (arg == "--force"))
       expander.setForce(true);
+    else if((arg == "-x") || (arg == "--xfile"))
+      expander.setXFile(true);
     else if(strBegins(arg, "--path=")) 
       expander.addPath(arg.substr(7));
     else if(strBegins(arg, "--tag=")) 


### PR DESCRIPTION
New app nspatch: ingests (1) a "stem" moos or bhv file, (2) one or more patch moos or bhv files, and outputs a modified moos file with the patch(es) applied to the stem. Designed to be a core tool for generating auto-test missions with only slight test/evaluation conditions, from a single stem mission. The older sister app, nsplug, was augmented with the -x or --xfile flag, to first look for a variant of the input file, e.g., meta_vehicle.moos, with the name meta_vehicle.moosx. The latter will at times be the output of an nspatch stage. 