### PR TITLE
fix(nsplug): Fix spaces in tags for nsplug

### DIFF
--- a/ivp/src/app_nsplug/Expander.cpp
+++ b/ivp/src/app_nsplug/Expander.cpp
@@ -128,7 +128,7 @@ vector<string> Expander::expandFile(string filename,
 
     // Begin tag support, added Sep 2020
     if(strBegins(line_orig, "<tag>")) {
-      curr_tag = stripChevrons(line_orig.substr(5));
+      curr_tag = stripChevrons(stripBlankEnds(line_orig.substr(5)));
       continue;
     }
     if((inctag != "") && (inctag != curr_tag))


### PR DESCRIPTION
Fixed #66: Handling of spaces in tags that don't contain chevrons for NSPlug.
