### PR TITLE
Swap MacOS 13 builds to 15 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,7 @@ jobs:
         include:
           - os: ubuntu-24.04
             os-type: debian
-          # Mac OS 13 runs on intel
-          - os: macos-13
+          - os: macos-15-intel
             os-type: darwin
           # MacOS 26 runs on arm64
           - os: macos-26


### PR DESCRIPTION
Impending deprecation of MacOX 13-based runners: https://github.com/actions/runner-images/issues/13046

`macOS-15-intel` is supported until 2027.