### PR TITLE
Mods to uLoadWatch and AppCastingMOOSApp superclass

### DIFF
--- a/MOOS_Jul0519/MOOSCore/Core/libMOOS/Thirdparty/AppCasting/include/MOOS/libMOOS/Thirdparty/AppCasting/AppCastingMOOSApp.h
+++ b/MOOS_Jul0519/MOOSCore/Core/libMOOS/Thirdparty/AppCasting/include/MOOS/libMOOS/Thirdparty/AppCasting/AppCastingMOOSApp.h
@@ -65,6 +65,7 @@ public:
   
  private:
   void         handleMailAppCastRequest(const std::string&);
+  void         handleMailLoadCastRequest(const std::string&);
   bool         handleMailCommsPolicy(const std::string&);
   bool         appcastRequested();
 
@@ -99,9 +100,15 @@ protected:
   std::string  m_comms_policy;
   std::string  m_comms_policy_config;
   
-  // Map from KEY (AC requestor) to config param.
+  // Map from KEY (APPCAST requestor) to config param.
   std::map<std::string, double>       m_map_bcast_duration;
   std::map<std::string, double>       m_map_bcast_tstart;
   std::map<std::string, std::string>  m_map_bcast_thresh;  
+
+  // Map from KEY (LOADCAST requestor) to config param.
+  double  m_lcast_duration;
+  double  m_lcast_tstart;
+  double  m_lcast_thresh;
+  bool    m_lcast_isdue;
 };
 #endif

--- a/editor-modes/moos-apps.el
+++ b/editor-modes/moos-apps.el
@@ -106,7 +106,7 @@
 
       '("pContactMgrV20" "alert" "alert_range_color" "cpa_range_color" "contact_max_age" "display_radii" "display_radii_id" "alert_verbose" "decay" "recap_interval" "ignore_group" "ignore_type" "match_type" "match_group" "match_region" "ignore_region" "strict_ignore" "range_report_timeout" "post_closest_range" "max_retired_history" "reject_range" "contact_max_age" "eval_range_far" "eval_range_near" "max_appcast_events" "post_all_ranges" "hold_alerts_for_helm" "post_closest_relbng" "disable_var" "enable_var" "able_flag" "enable_flag" "disable_flag" "early_warning_flag" "early_warning_radii" "early_warning_time" "ewarn_radii_color" "cease_warning_flag" )
 
-      '("uLoadWatch" "thresh" "breach_trigger" "max_appcast_events")
+      '("uLoadWatch" "thresh" "breach_trigger" "max_appcast_events" "near_breach_thresh" )
       '("uSimLidar" "poly" "polygon" "max_range" "mount_angle" "point_cloud_color" "range" "beams" "field_of_view" "scan_resolution" "max_appcast_events")
       '("iSay" "default_voice" "default_rate" "interval_policy" "min_utter_interval" "audio_dir" "os_mode" "max_appcast_events" "volume" )
       '("uXMS" "var" "source" "history_var" "display_virgins" "display_source" "display_aux_source" "display_time" "display_community" "display_all" "trunc_data" "term_report_interval" "colormap" "color_map" "refresh_mode" "content_mode" "paused")

--- a/ivp/src/uLoadWatch/LoadWatch.h
+++ b/ivp/src/uLoadWatch/LoadWatch.h
@@ -45,7 +45,8 @@ class LoadWatch : public AppCastingMOOSApp
    
  protected:
   void registerVariables();
-  
+
+  bool handleMailLoadCast(std::string);
   void handleCacheIterGap();
   void handleCacheIterGapEntry(std::string app, double dval);
   void handleCacheIterLen();
@@ -53,13 +54,17 @@ class LoadWatch : public AppCastingMOOSApp
   bool handleConfigThresh(std::string);
   bool handleConfigNearThresh(std::string);
 
+  void postLoadCastRequests();
+  
   void updateBreachSet(std::string app);
   void updateNearBreachSet(std::string app);
   
  private: // Configuration variables
   std::map<std::string, double> m_map_thresh;
-  unsigned int                  m_breach_trigger;
-   
+
+  unsigned int  m_breach_trigger;
+  double        m_lcast_req_freq;     
+  
  private: // State variables
   std::map<std::string, double>       m_map_app_gap_total;
   std::map<std::string, double>       m_map_app_gap_max;
@@ -82,6 +87,7 @@ class LoadWatch : public AppCastingMOOSApp
   std::map<std::string, double> m_map_gap_cache;
   std::map<std::string, double> m_map_len_cache;
 
+  double m_last_lcast_req_utc;
 };
 
 #endif 

--- a/ivp/src/uLoadWatch/LoadWatch_Info.cpp
+++ b/ivp/src/uLoadWatch/LoadWatch_Info.cpp
@@ -128,6 +128,7 @@ void showInterfaceAndExit()
   blk("PUBLICATIONS:                                                   ");
   blk("------------------------------------                            ");
   blk("  LOAD_WARNING = app=pHelmIvP, maxgap=1.54                      ");
+  blk("  LOADCAST_REQ = app=pHelmIvP, duration=35, thresh=2            ");
   blk("                                                                ");
   blk("  ULW_BREACH       = true                                       ");
   blk("  ULW_BREACH_COUNT = 3                                          ");


### PR DESCRIPTION
Post Release 24.8, uLoadWatch has been modified to publish a "loadcast" request to the apps it is watching. Only these
apps will generate _ITER_GAP and _ITER_LEN postings. All other apps will not post this information. This change
is on conjunction with the AppCastingMOOSApp superclass, the super class for most apps in the MOOS-IvP release. The motivation of this change is to reduce log file bloat and MOOSDB traffic. Neither reduction was deemed critical, but it was inefficient. These two variable postings, for each app, are essentially only published to be consumed by uLoadWatch.  If this app is not even being run in a mission, there is arguably no reason for apps be publishing these variables.