### PR TITLE
Remove `sudo` from docker images

### DIFF
--- a/docker/moos-ivp-gui/Dockerfile
+++ b/docker/moos-ivp-gui/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="/home/moos/moos-ivp/bin:${PATH}"
 ENV IVP_BEHAVIOR_DIRS="/home/moos/moos-ivp/lib"
 
 # Make a user to run the MOOS apps
-RUN useradd -m -p "moos" moos && usermod -a -G sudo moos
+RUN useradd -m "moos"
 
 # Set the default user
 USER moos
@@ -27,7 +27,7 @@ ARG SOURCE_DATE_EPOCH=""
 USER root
 
 # Base
-RUN apt-get update -y && apt-get install -y cmake build-essential lsb-release sudo && apt-get clean
+RUN apt-get update -y && apt-get install -y cmake build-essential lsb-release && apt-get clean
 
 # GUI
 RUN apt-get update -y && apt-get install -y libtiff5-dev libfltk1.3-dev freeglut3-dev libpng-dev libjpeg-dev libxinerama-dev libxft-dev && apt-get clean

--- a/docker/moos-ivp/Dockerfile
+++ b/docker/moos-ivp/Dockerfile
@@ -9,10 +9,10 @@ ENV PATH="/home/moos/moos-ivp/bin:${PATH}"
 ENV IVP_BEHAVIOR_DIRS="/home/moos/moos-ivp/lib"
 
 # Install required MOOS dependencies
-RUN apt-get update -y && apt-get install -y cmake build-essential lsb-release sudo && apt-get clean
+RUN apt-get update -y && apt-get install -y cmake build-essential lsb-release && apt-get clean
 
 # Make a user to run the MOOS apps
-RUN useradd -m -p "moos" moos && usermod -a -G sudo moos
+RUN useradd -m "moos"
 
 # Set the default user
 USER moos


### PR DESCRIPTION
Addresses #88, supersedes https://github.com/moos-ivp/moos-ivp/pull/89

Currently, we package `sudo` in the Docker container for moos, and set the `moos` users's password to a hardcoded password. This PR removes the hardcoded password, and no longer installs `sudo` in the image.

I introduced this dependency while I was actively developing the container, and having the ability to quickly escalate was useful. However, #88 brought it back to my attention. PR #89 makes things more cryptographically secure (and a functional password) by using a random salt with the password, but Copilot mentioned this would break image layer caching, and wasn't fundamentally more secure (since the plaintext password is still embedded in the layer metadata). It's also [discouraged](https://www.docker.com/blog/understanding-the-docker-user-instruction/) by Docker themselves.

I don't think this is a fundamental breakage of many use-cases. Any downstream image depending on this image can use `USER root` to [install dependencies](https://github.com/HeroCC/moos-ivp-cc/blob/7227067fa22dfc28cda390c3f22b861765e3c743/Dockerfile#L30-L34), or even reintroduce sudo + the user password if they prefer the old behavior. Users who wish to run the image _and_ have root can pass `docker run --user root` and deescalate themselves when they see fit.