### PR TITLE
Ignore clang cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ CMakeFiles
 **/*.swp
 **/.vagrant*
 build/*
+.cache/
 build-utests/*
 include/
 lib/*


### PR DESCRIPTION
Simple gitignore addition to ignore the `.cache/` directory created when using clang to compile files on MacOS.