### PR TITLE
License clarification

### DIFF
--- a/ivp/src/lib_behaviors-colregs/VelocityFilter.cpp
+++ b/ivp/src/lib_behaviors-colregs/VelocityFilter.cpp
@@ -1,13 +1,25 @@
-/***************************************************************/
-/*    NAME: Michael Benjamin                                   */
-/*    ORGN: MIT, Cambridge MA                                  */
-/*    FILE: VelocityFilter.cpp                                 */
-/*    DATE: Apr 23rd, 2022                                     */
-/*                                                             */
-/* This is unreleased BETA code. No permission is granted or   */
-/* implied to use, copy, modify, and distribute this software  */
-/* except by the author(s), or those designated by the author. */
-/***************************************************************/
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: MIT, Cambridge MA                                    */
+/*    FILE: VelocityFilter.cpp                                   */
+/*    DATE: Apr 23rd, 2022                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #include <vector>
 #include <iterator>

--- a/ivp/src/lib_behaviors-colregs/VelocityFilter.h
+++ b/ivp/src/lib_behaviors-colregs/VelocityFilter.h
@@ -1,13 +1,25 @@
-/***************************************************************/
-/*    NAME: Michael Benjamin                                   */
-/*    ORGN: MIT, Cambridge MA                                  */
-/*    FILE: VelocityFilter.h                                   */
-/*    DATE: Apr 23rd, 2022                                     */
-/*                                                             */
-/* This is unreleased BETA code. No permission is granted or   */
-/* implied to use, copy, modify, and distribute this software  */
-/* except by the author(s), or those designated by the author. */
-/***************************************************************/
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: MIT, Cambridge MA                                    */
+/*    FILE: VelocityFilter.h                                     */
+/*    DATE: Apr 23rd, 2022                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #ifndef VELOCITY_FILTER_HEADER
 #define VELOCITY_FILTER_HEADER

--- a/ivp/src/lib_behaviors-marine/BHV_PModelView.cpp
+++ b/ivp/src/lib_behaviors-marine/BHV_PModelView.cpp
@@ -1,9 +1,25 @@
-/*********************************************************/
-/*    NAME: Michael Benjamin                             */
-/*    ORGN: Dept of Mechanical Eng, MIT Cambridge MA     */
-/*    FILE: BHV_PModelView.cpp                           */
-/*    DATE: Nov 3rd 2023                                 */
-/*********************************************************/
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: BHV_PModelView.cpp                                   */
+/*    DATE: Nov 3rd, 2023                                        */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #include <iostream>
 #include "BHV_PModelView.h"

--- a/ivp/src/lib_behaviors-marine/BHV_PModelView.h
+++ b/ivp/src/lib_behaviors-marine/BHV_PModelView.h
@@ -1,9 +1,25 @@
-/***********************************************************/
-/*    NAME: Michael Benjamin                               */
-/*    ORGN: Dept of Mechanical Eng, MIT Cambridge MA       */
-/*    FILE: BHV_PModelView.h                               */
-/*    DATE: Nov 3rd, 2023                                  */
-/***********************************************************/
+/*****************************************************************/
+/*    NAME: Michael Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: BHV_PModelView.h                                     */
+/*    DATE: Nov 3rd, 2023                                        */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
  
 #ifndef BHV_PMODEL_VIEW_HEADER
 #define BHV_PMODEL_VIEW_HEADER

--- a/ivp/src/lib_bhvutil/FixedTurn.cpp
+++ b/ivp/src/lib_bhvutil/FixedTurn.cpp
@@ -4,20 +4,22 @@
 /*    FILE: FixedTurn.cpp                                        */
 /*    DATE: Jan 1st 2023                                         */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_bhvutil/FixedTurn.h
+++ b/ivp/src/lib_bhvutil/FixedTurn.h
@@ -4,20 +4,22 @@
 /*    FILE: FixedTurn.h                                          */
 /*    DATE: Jan 1st 2023                                         */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_bhvutil/FixedTurnSet.cpp
+++ b/ivp/src/lib_bhvutil/FixedTurnSet.cpp
@@ -4,20 +4,22 @@
 /*    FILE: FixedTurnSet.cpp                                     */
 /*    DATE: Jan 2nd 2023                                         */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_bhvutil/FixedTurnSet.h
+++ b/ivp/src/lib_bhvutil/FixedTurnSet.h
@@ -4,20 +4,22 @@
 /*    FILE: FixedTurnSet.h                                       */
 /*    DATE: Jan 2nd 2023                                         */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_bhvutil/LegRun.cpp
+++ b/ivp/src/lib_bhvutil/LegRun.cpp
@@ -1,9 +1,27 @@
-/************************************************************/
+/*****************************************************************/
 /*    NAME: Mike Benjamin                                   */
 /*    ORGN: MIT, Cambridge MA                               */
 /*    FILE: LegRun.cpp                                      */
 /*    DATE: May 26th, 2023                                  */
-/************************************************************/
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*                                                               */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
+/*                                                               */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #include <iterator>
 #include "GeomUtils.h"

--- a/ivp/src/lib_bhvutil/LegRun.h
+++ b/ivp/src/lib_bhvutil/LegRun.h
@@ -1,9 +1,27 @@
-/************************************************************/
+/*****************************************************************/
 /*    NAME: Mike Benjamin                                   */
 /*    ORGN: MIT, Cambridge MA                               */
 /*    FILE: LegRun.h                                        */
 /*    DATE: May 26th, 2023                                  */
-/************************************************************/
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*                                                               */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
+/*                                                               */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #ifndef LEG_RUN_OBJ_HEADER
 #define LEG_RUN_OBJ_HEADER

--- a/ivp/src/lib_bhvutil/LegRunSet.cpp
+++ b/ivp/src/lib_bhvutil/LegRunSet.cpp
@@ -1,9 +1,27 @@
-/************************************************************/
+/*****************************************************************/
 /*    NAME: Mike Benjamin                                   */
 /*    ORGN: MIT, Cambridge MA                               */
 /*    FILE: LegRunSet.cpp                                   */
 /*    DATE: June 11th, 2023                                 */
-/************************************************************/
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*                                                               */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
+/*                                                               */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #include <iterator>
 #include "GeomUtils.h"

--- a/ivp/src/lib_bhvutil/LegRunSet.h
+++ b/ivp/src/lib_bhvutil/LegRunSet.h
@@ -1,9 +1,27 @@
-/************************************************************/
+/*****************************************************************/
 /*    NAME: Mike Benjamin                                   */
 /*    ORGN: MIT, Cambridge MA                               */
 /*    FILE: LegRunSet.h                                     */
 /*    DATE: June 11th, 2023                                 */
-/************************************************************/
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*                                                               */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
+/*                                                               */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #ifndef LEG_RUN_SET_HEADER
 #define LEG_RUN_SET_HEADER

--- a/ivp/src/lib_dep_behaviors/BHV_FixTurn.cpp
+++ b/ivp/src/lib_dep_behaviors/BHV_FixTurn.cpp
@@ -4,9 +4,21 @@
 /*    FILE: BHV_FixTurn.cpp                                      */
 /*    DATE: Oct 16th 2022                                        */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #include <cmath>

--- a/ivp/src/lib_dep_behaviors/BHV_FixTurn.h
+++ b/ivp/src/lib_dep_behaviors/BHV_FixTurn.h
@@ -4,9 +4,21 @@
 /*    FILE: BHV_FixTurn.h                                        */
 /*    DATE: Oct 16th 2022                                        */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #ifndef BHV_FIX_TURN_HEADER

--- a/ivp/src/lib_geometry/OpField.cpp
+++ b/ivp/src/lib_geometry/OpField.cpp
@@ -1,9 +1,27 @@
-/************************************************************/
+/*****************************************************************/
 /*    NAME: Mike Benjamin                                   */
 /*    ORGN: MIT, Cambridge MA                               */
 /*    FILE: OpField.cpp                                     */
 /*    DATE: September 25th, 2023                            */
-/************************************************************/
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*                                                               */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
+/*                                                               */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #include <iterator>
 #include "MBUtils.h"

--- a/ivp/src/lib_geometry/OpField.h
+++ b/ivp/src/lib_geometry/OpField.h
@@ -1,9 +1,27 @@
-/************************************************************/
+/*****************************************************************/
 /*    NAME: Mike Benjamin                                   */
 /*    ORGN: MIT, Cambridge MA                               */
 /*    FILE: OpField.h                                       */
 /*    DATE: Sep 25th, 2023                                  */
-/************************************************************/
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*                                                               */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
+/*                                                               */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
 
 #ifndef OP_FIELD_HEADER
 #define OP_FIELD_HEADER

--- a/ivp/src/lib_geometry/Populator_OpField.cpp
+++ b/ivp/src/lib_geometry/Populator_OpField.cpp
@@ -4,20 +4,22 @@
 /*    FILE: Populator_OpField.cpp                                */
 /*    DATE: Nov 23rd, 2023                                       */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_geometry/Populator_OpField.h
+++ b/ivp/src/lib_geometry/Populator_OpField.h
@@ -1,23 +1,25 @@
 /*****************************************************************/
 /*    NAME: Michael Benjamin                                     */
 /*    ORGN: Dept of Mechanical Eng / MIT Cambridge MA            */
-/*    FILE: Populator_TaskDiary.h                                */
+/*    FILE: Populator_OpField.h                                  */
 /*    DATE: Nov 23rd, 2023                                       */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_helmivp/PMGen.cpp
+++ b/ivp/src/lib_helmivp/PMGen.cpp
@@ -4,9 +4,21 @@
 /*    FILE: PMGen.cpp                                            */
 /*    DATE: Jan 1st, 2024                                        */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #include "AngleUtils.h"

--- a/ivp/src/lib_helmivp/PMGen.h
+++ b/ivp/src/lib_helmivp/PMGen.h
@@ -4,9 +4,21 @@
 /*    FILE: PMGen.h                                              */
 /*    DATE: Oct 24th, 2023                                       */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #ifndef PMGEN_HEADER

--- a/ivp/src/lib_helmivp/PMGen_Dubins.cpp
+++ b/ivp/src/lib_helmivp/PMGen_Dubins.cpp
@@ -4,9 +4,21 @@
 /*    FILE: PMGen_Dubins.cpp                                     */
 /*    DATE: Oct 24th, 2023                                       */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #include "PMGen_Dubins.h"

--- a/ivp/src/lib_helmivp/PMGen_Dubins.h
+++ b/ivp/src/lib_helmivp/PMGen_Dubins.h
@@ -4,9 +4,21 @@
 /*    FILE: PMGen_Dubins.h                                       */
 /*    DATE: Oct 24th, 2023                                       */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #ifndef PMGEN_DUBINS_HEADER

--- a/ivp/src/lib_helmivp/PMGen_Holonomic.cpp
+++ b/ivp/src/lib_helmivp/PMGen_Holonomic.cpp
@@ -4,9 +4,21 @@
 /*    FILE: PMGen_Holonomic.cpp                                  */
 /*    DATE: Oct 24th, 2023                                       */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #include "MBUtils.h"

--- a/ivp/src/lib_helmivp/PMGen_Holonomic.h
+++ b/ivp/src/lib_helmivp/PMGen_Holonomic.h
@@ -4,9 +4,21 @@
 /*    FILE: PMGen_Holonomic.h                                    */
 /*    DATE: Oct 24th, 2023                                       */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #ifndef PMGEN_HOLONOMIC_HEADER

--- a/ivp/src/lib_helmivp/PlatModelGenerator.cpp
+++ b/ivp/src/lib_helmivp/PlatModelGenerator.cpp
@@ -4,9 +4,21 @@
 /*    FILE: PlatModelGenerator.cpp                               */
 /*    DATE: Oct 24th, 2023                                       */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #include "MBUtils.h"

--- a/ivp/src/lib_helmivp/PlatModelGenerator.h
+++ b/ivp/src/lib_helmivp/PlatModelGenerator.h
@@ -4,9 +4,21 @@
 /*    FILE: PlatModelGenerator.h                                 */
 /*    DATE: Oct 24th, 2023                                       */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s), or those designated by the author.   */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #ifndef PLAT_MODEL_GENERATOR_HEADER

--- a/ivp/src/lib_marineview/glext.h
+++ b/ivp/src/lib_marineview/glext.h
@@ -1,10 +1,14 @@
 /*****************************************************************/
 /*    NAME: Michael Benjamin                                     */
 /*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
-/*    FILE:                                                      */
+/*    FILE: glext.h                                              */
 /*    DATE:                                                      */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* MOOS-IvP provides only this comment block and the include     */
+/* guard below under GPLv3. From the Khronos Group copyright     */
+/* notice onward, this file contains third-party Materials       */
+/* licensed solely under the permissive Khronos terms shown    */
+/* there, not under GPLv3.                                       */
 /*                                                               */
 /* MOOS-IvP is free software: you can redistribute it and/or     */
 /* modify it under the terms of the GNU General Public License   */

--- a/ivp/src/lib_mbutil/JsonUtils.cpp
+++ b/ivp/src/lib_mbutil/JsonUtils.cpp
@@ -4,20 +4,22 @@
 /*    FILE: JsonUtils.cpp                                        */
 /*    DATE: January 12th, 2025                                   */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_mbutil/JsonUtils.h
+++ b/ivp/src/lib_mbutil/JsonUtils.h
@@ -4,20 +4,22 @@
 /*    FILE: JsonUtils.h                                          */
 /*    DATE: Jan 12th, 2025                                       */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_mbutil/VQuals.cpp
+++ b/ivp/src/lib_mbutil/VQuals.cpp
@@ -4,20 +4,22 @@
 /*    FILE: VQuals.cpp                                           */
 /*    DATE: Mar 9th, 2024                                        */
 /*                                                               */
-/* This file is part of MOOS-IvP                                 */
+/* This file is part of IvP Helm Core Libs                       */
 /*                                                               */
-/* MOOS-IvP is free software: you can redistribute it and/or     */
-/* modify it under the terms of the GNU General Public License   */
-/* as published by the Free Software Foundation, either version  */
-/* 3 of the License, or (at your option) any later version.      */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
 /*                                                               */
-/* MOOS-IvP is distributed in the hope that it will be useful,   */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
-/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
-/* the GNU General Public License for more details.              */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
 /*                                                               */
-/* You should have received a copy of the GNU General Public     */
-/* License along with MOOS-IvP.  If not, see                     */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 

--- a/ivp/src/lib_survey/SurveyGenerator.h
+++ b/ivp/src/lib_survey/SurveyGenerator.h
@@ -4,9 +4,23 @@
 /*    FILE: SurveyGenerator.h                                    */
 /*    DATE: August 15th, 2020                                    */
 /*                                                               */
-/* This is unreleased BETA code. No permission is granted or     */
-/* implied to use, copy, modify, and distribute this software    */
-/* except by the author(s).                                      */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*                                                               */
+/* IvP Helm Core Libs is distributed in the hope that it will    */
+/* be useful but WITHOUT ANY WARRANTY; without even the implied  */
+/* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR       */
+/* PURPOSE. See the Lesser GNU General Public License for more   */
+/* details.                                                      */
+/*                                                               */
+/* You should have received a copy of the Lesser GNU General     */
+/* Public License along with MOOS-IvP.  If not, see              */
+/* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
 #ifndef SURVEY_GENERATOR_HEADER


### PR DESCRIPTION
# What
This PR to aligns all `lib_`s to have a coherent licensing. Some libraries were mixes of LGPL + GPL code, others had BETA headers which are not free software.

Typically, library which contains LGPL _and_ GPL files is often treated as GPL, so I tried to align towards LGPL if it seemed reasonable to do so. Same line of reasoning for the BETA code. 

# Why

Technically a package _can_ be [distributed](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#license-syntax) as requiring compliance with both licenses (`AND`), but doing so prevents machines from interpreting the license automatically (and often times to err on the cautious side, consumers take the stricter path for the entire package), so I prefer against it. 

# Additional Info

I'll follow up with a PR doing similar fixes for apps. And another PR introducing some sort of automatic license header checking tool (potentially [this](https://github.com/apache/skywalking-eyes)) & replacing the header blobs with copyright and [SPDX](https://spdx.dev/learn/handling-license-info/#why) strings.

Below is a table of each library under `ivp/src/` and their respective license status. Some of the code had ambiguous or mixed licensing. 
<details><summary>Table of Libraries and Previous License Status</summary>
<p>

Library | Dominant license (from headers) | Other / emphasis
-- | -- | --
lib_apputil | GPL | Uniform
lib_behaviors | LGPL | Uniform
lib_behaviors-colregs | GPL | BETA on VelocityFilter.cpp / .h (restrictive, not GPL)
lib_behaviors-marine | GPL | No license block on BHV_PModelView.cpp / .h (author header only)
lib_bhvutil | LGPL | Mixed with GPL: FixedTurn.cpp, FixedTurn.h, FixedTurnSet.cpp, FixedTurnSet.h are GPL; no license on LegRun* and LegRunSet* (author header only)
lib_contacts | GPL | Uniform
lib_dep_behaviors | GPL + LGPL | Mixed: obstacle/AOF pieces are LGPL; several behaviors GPL; BETA on BHV_FixTurn.cpp / .h
lib_encounters | GPL | Uniform
lib_evalutil | GPL | Uniform
lib_genutil | GPL | Uniform
lib_geodaid | GPL | Uniform
lib_geometry | LGPL | Mixed with GPL: Populator_OpField.cpp / .h are GPL; no license on OpField* (author header only)
lib_helmivp | GPL | BETA / restrictive on PMGen*, PlatModelGenerator* (8 files): not GPL despite rest of library
lib_ipfview | GPL | Uniform
lib_ivpbuild | LGPL | Uniform
lib_ivpcore | LGPL | Uniform
lib_ivpsolve | LGPL | Uniform
lib_logic | LGPL | Uniform
lib_logutils | GPL | attic/SplitHandlerBundle.{cpp,h}: author header, no license text
lib_manifest | GPL | Uniform
lib_marine_pid | LGPL | Uniform
lib_marineview | GPL | glext.h: MOOS-IvP GPL banner at top + Khronos MIT-like license for the bulk of the file → mixed in one file
lib_mbutil | LGPL | Mixed with GPL: JsonUtils.cpp / .h, VQuals.cpp are GPL
lib_obstacles | GPL | Uniform
lib_polar | LGPL | Uniform
lib_realm | LGPL | Uniform
lib_survey | LGPL (implementation) | SurveyGenerator.h is BETA/restrictive while SurveyGenerator.cpp is LGPL → inconsistent pair
lib_turngeo | GPL | Uniform
lib_ucommand | GPL | Uniform
lib_ufield | GPL | Uniform
lib_zaicview | GPL | Uniform

</p>
</details> 
