### PR TITLE
Support .tiff background image filenames

### DIFF
--- a/ivp/src/app_alogview/LogViewLauncher.cpp
+++ b/ivp/src/app_alogview/LogViewLauncher.cpp
@@ -28,6 +28,7 @@
 #include "MBTimer.h"
 #include "LogViewLauncher.h"
 #include "FileBuffer.h"
+#include "TiffUtils.h"
 
 using namespace std;
 
@@ -178,7 +179,7 @@ bool LogViewLauncher::handleConfigParam(string argi)
     handled = handleVQual(argi.substr(8));
   else if(strBegins(argi, "--bg="))
     handled = handleBackground(argi.substr(5));
-  else if(strEnds(argi, ".tif")) 
+  else if(isTiffFile(argi))
     handled = handleBackground(argi);
   else if(strBegins(argi, "--detached=")) 
     m_dbroker.addDetachedPair(argi.substr(11));
@@ -491,7 +492,7 @@ bool LogViewLauncher::handleMaxTime(string val)
 
 
 //-------------------------------------------------------------
-// Procedure: handleBackground  --bg=FILE.tif
+// Procedure: handleBackground  --bg=FILE.tif[f]
 
 bool LogViewLauncher::handleBackground(string val)
 {
@@ -510,7 +511,7 @@ bool LogViewLauncher::handleBackground(string val)
   else
     m_tiff_file = val;
   
-  if(!strEnds(m_tiff_file, ".tif"))
+  if(!isTiffFile(m_tiff_file))
     return(false);
 
   m_tiff_files.push_back(m_tiff_file);

--- a/ivp/src/app_alogview/main.cpp
+++ b/ivp/src/app_alogview/main.cpp
@@ -118,7 +118,8 @@ void help_message()
   cout << "  -v,--version    Displays the current release version        " << endl;
   cout << "  -vb, --verbose  Verbose output                              " << endl;
   cout << "                                                              " << endl;
-  cout << "  --bg=file.tiff  Specify an alternate background image.      " << endl;
+  cout << "  --bg=file.tif   Specify an alternate background image.      " << endl;
+  cout << "                  Both .tif and .tiff suffixes are supported. " << endl;
   cout << "                                                              " << endl;
   cout << "  --lp=VEH:VAR    Specify starting left log plot.             " << endl;
   cout << "  --rp=VEH:VAR    Specify starting right log plot.            " << endl;

--- a/ivp/src/app_geoview/main.cpp
+++ b/ivp/src/app_geoview/main.cpp
@@ -33,6 +33,7 @@
 #include "XYGrid.h"
 #include "XYCircle.h"
 #include "LMV_Utils.h"
+#include "TiffUtils.h"
 #include "XYFormatUtilsPoly.h"
 #include "XYFormatUtilsPoint.h"
 
@@ -94,7 +95,7 @@ int main(int argc, char *argv[])
   for(i=1; i<argc; i++) {
     string argi  = argv[i];
     
-    if(strContains(argi, ".tif"))
+    if(isTiffFile(argi))
       tif_file = argi;
     else if(argi == "-noimg")
       tif_file = "";

--- a/ivp/src/lib_marineview/BackImg.cpp
+++ b/ivp/src/lib_marineview/BackImg.cpp
@@ -49,6 +49,7 @@
 #endif
 
 #include "BackImg.h"
+#include "TiffUtils.h"
 #include "MBUtils.h"
 #include "FileBuffer.h"
 #include "MOOS/libMOOSGeodesy/MOOSGeodesy.h"
@@ -189,7 +190,7 @@ bool BackImg::readTiff(string filename)
   bool ok2 = readTiffInfo(m_info_file);
 
 #if 0
-  string info_file = findReplace(filename, ".tif", ".info");
+  string info_file = tiffToInfoFile(filename);
 
   bool ok1 = readTiffData(filename);  
   bool ok2 = readTiffInfo(info_file);
@@ -208,7 +209,7 @@ bool BackImg::locateTiffAndInfoFiles(string tiff_file)
   if(tiff_file == "")
     return(false);
 
-  string info_file = findReplace(tiff_file, ".tif", ".info");
+  string info_file = tiffToInfoFile(tiff_file);
 
   // =========================================================
   // Part 1: Most often (likely) image is just alpha or MIT mission

--- a/ivp/src/lib_marineview/CMakeLists.txt
+++ b/ivp/src/lib_marineview/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(SRC
   MarineViewer.cpp
   OpAreaSpec.cpp
   LMV_Utils.cpp
+  TiffUtils.cpp
 #  VehicleSet.cpp
 )
 

--- a/ivp/src/lib_marineview/MarineViewer.cpp
+++ b/ivp/src/lib_marineview/MarineViewer.cpp
@@ -34,6 +34,7 @@
 #include <cstdlib>
 #include <cmath>
 #include "MarineViewer.h"
+#include "TiffUtils.h"
 #include "MBUtils.h"
 #include "GeomUtils.h"
 #include "AngleUtils.h"
@@ -243,7 +244,7 @@ bool MarineViewer::setParam(string param, string value)
       return(false);
     if(strBegins(value, "="))
       return(false);
-    if(!strEnds(value, ".tif"))
+    if(!isTiffFile(value))
       return(false);
     if(value == "null.tif")
       handled = handleNoTiff();

--- a/ivp/src/lib_marineview/TiffUtils.cpp
+++ b/ivp/src/lib_marineview/TiffUtils.cpp
@@ -1,0 +1,47 @@
+/*****************************************************************/
+/*    NAME: Charles Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: TiffUtils.cpp                                        */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#include "TiffUtils.h"
+#include "MBUtils.h"
+
+using namespace std;
+
+//--------------------------------------------------------
+// Procedure: isTiffFile
+
+bool isTiffFile(const string& filename)
+{
+  return(strEnds(filename, ".tif") || strEnds(filename, ".tiff"));
+}
+
+//--------------------------------------------------------
+// Procedure: tiffToInfoFile
+
+string tiffToInfoFile(const string& filename)
+{
+  if(strEnds(filename, ".tiff"))
+    return(filename.substr(0, filename.length()-5) + ".info");
+  if(strEnds(filename, ".tif"))
+    return(filename.substr(0, filename.length()-4) + ".info");
+
+  return("");
+}

--- a/ivp/src/lib_marineview/TiffUtils.h
+++ b/ivp/src/lib_marineview/TiffUtils.h
@@ -1,0 +1,31 @@
+/*****************************************************************/
+/*    NAME: Charles Benjamin                                     */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: TiffUtils.h                                          */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#ifndef TIFF_UTILS_HEADER
+#define TIFF_UTILS_HEADER
+
+#include <string>
+
+bool isTiffFile(const std::string&);
+std::string tiffToInfoFile(const std::string&);
+
+#endif

--- a/ivp/src/pMarineViewer/PMV_Info.cpp
+++ b/ivp/src/pMarineViewer/PMV_Info.cpp
@@ -94,6 +94,7 @@ void showExampleConfigAndExit()
   blk("  CommsTick = 4                                                 ");
   blk("                                                                ");
   blk("  // BackView Options ==========================================");
+  blk("  // TIFF images may use either a .tif or .tiff suffix          ");
   blk("  tiff_file            = forrest19.tif                          ");
   blk("  set_pan_x            = -90                                    ");
   blk("  set_pan_y            = -280                                   ");

--- a/ivp/src/pMarineViewer/PMV_MOOSApp.cpp
+++ b/ivp/src/pMarineViewer/PMV_MOOSApp.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <iostream>
 #include "PMV_MOOSApp.h"
+#include "TiffUtils.h"
 #include "MBUtils.h"
 #include "HashUtils.h"
 #include "MacroUtils.h"
@@ -987,7 +988,7 @@ void PMV_MOOSApp::handleStartUp(const MOOS_event & e) {
     vector<string> tiff_files = m_gui->mviewer->getTiffFiles();
     for(unsigned int i=0; i<tiff_files.size(); i++) {
       string tiff_file = tiff_files[i];
-      string info_file = findReplace(tiff_files[i], ".tif", ".info");
+      string info_file = tiffToInfoFile(tiff_files[i]);
       string command = "COPY_FILE_REQUEST=";
       if(tiff_file != "") {
 	Notify("PLOGGER_CMD", command + tiff_file);


### PR DESCRIPTION
## Summary

Allow TIFF background images to use either the `.tif` or `.tiff`
filename suffix in:

- pMarineViewer
- alogview
- geoview

This preserves existing `.tif` behavior.

## Implementation

Add shared helpers to:

- recognize terminal `.tif` and `.tiff` suffixes
- derive the companion `.info` filename from either suffix

Use these helpers for:

- MarineViewer filename validation
- BackImg image/metadata discovery
- pMarineViewer `PLOGGER_CMD` copy requests
- alogview background argument handling
- geoview image argument handling

This is important because merely accepting `.tiff` would cause the old
literal replacement logic to derive `chart.infof` instead of
`chart.info`.

## Validation

### macOS build

Clean builds passed for:

- pMarineViewer
- alogview
- geoview

### Linux build

A fresh checkout of this branch was built in an Ubuntu 24.04 ARM64
container using GCC 13.3 and the dependencies documented in
`README-GNULINUX.txt`.

Both `build-moos.sh` and `build-ivp.sh` completed successfully.

### Mission launches

Two separate pAntler missions were launched with MOOSDB and
pMarineViewer.

The missions used byte-identical copies of `MIT_SP.tif`; the second copy
was renamed to `MIT_SP.tiff`.

Both missions successfully:

- accepted the configured filename
- found `MIT_SP.info`
- opened the image through libtiff
- loaded the OpenGL texture
- shut down all pAntler processes cleanly

I visually inspected both pMarineViewer windows and verified that the
background image rendered correctly in both the `.tif` and `.tiff`
missions.

Existing `.tif` behavior therefore remains functional, while `.tiff`
is now accepted.

### alogview and geoview runtime tests

alogview and geoview were each tested twice using byte-identical copies
of the packaged MIT image:

1. `MIT_SP.tif`
2. the same file renamed to `MIT_SP.tiff`

The `.tif` and `.tiff` files had the same SHA-256 hash. Their companion
`MIT_SP.info` files were also identical.

In all four launches, the application:

- accepted the requested filename
- opened the exact configured image path
- found the corresponding `MIT_SP.info`
- successfully loaded the TIFF data
- reported no failed or unhandled image configuration

I visually inspected the `.tif` and `.tiff` launches in both alogview
and geoview and verified that the background image rendered correctly
in all four cases.

This provides a `.tif` regression test and a controlled `.tiff`
acceptance test for both applications.

### pLogger integration

pMarineViewer was launched with `log_the_image=true`. For the `.tiff`
case, the observed `PLOGGER_CMD` correctly requested `MIT_SP.info`, not
`MIT_SP.infof`.

## TexWiki documentation follow-up

The published pMarineViewer, alogview, and background-image manuals are
generated from a separate LaTeX/TexWiki source that is not present in
this repository.

References to `.tif` in that source need to be reviewed. The following
changes are needed:

1. **pMarineViewer Section 3.2 — Background Images**

   Update the text that says an image such as `dabob_bay.tif` is paired
   with `dabob_bay.info`, and that only the `.tif` file is configured.

   Replacement text:

   > A TIFF image ending in `.tif` or `.tiff` is paired with an `.info`
   > file using the same basename. For example, both `dabob_bay.tif`
   > and `dabob_bay.tiff` use `dabob_bay.info`.

2. **Section 4.2 — Image File Format and Meta Data**

   Replace statements that TIFF files “have the suffix `.tif`” with:

   > TIFF image filenames may end in `.tif` or `.tiff`.

   Replace “Each `.tif` file has a corresponding `.info` file” with:

   > Each TIFF image has a corresponding `.info` file using the same
   > basename.

3. **Section 4.4 — Loading Images at Run Time**

   Add a `.tiff` example for both applications:

   ```text
   tiff_file = harbor_chart.tiff
   alogview --bg=harbor_chart.tiff file.alog
   ```

4. **Section 4.6 — Background Image Path**

   Replace references to finding “the named `.tif` file” with finding
   “the named `.tif` or `.tiff` file.”

5. **Section 4.7.1 — pMarineViewer troubleshooting**

   Remove the existing instruction:

   > Make sure your image file name ends in `.tif` and not `.tiff`.

   Replace it with:

   > Make sure the image filename ends in `.tif` or `.tiff` and that
   > the companion `.info` file uses the same basename.

6. **Section 4.7.3 — alogview troubleshooting**

   Apply the same replacement to the repeated instruction requiring
   `.tif` rather than `.tiff`.

7. **Configuration parameter table — `tiff_file`**

   Replace the current description with:

   > Filename of a TIFF background image. Accepted filename suffixes
   > are `.tif` and `.tiff`.

8. **Recent Changes**

   Add:

   > pMarineViewer, alogview, and geoview now support both `.tif` and
   > `.tiff` background-image filename suffixes.

The corresponding generated pages and PDFs should then be regenerated:

- `app_pmviewer.pdf`
- `app_alogview.pdf`
- `help_mip_bkg_images.pdf`
- the pMarineViewer TexWiki page
- the alogview TexWiki page
- the Background Region Images help page
