### PR TITLE
Fix pMarineViewer texture ID buffer overflow with multiple backgrounds

### DIFF
--- a/ivp/src/lib_marineview/MarineViewer.cpp
+++ b/ivp/src/lib_marineview/MarineViewer.cpp
@@ -79,7 +79,6 @@ MarineViewer::MarineViewer(int x, int y, int w, int h, const char *l)
   m_hash_shade  = 0.65;
   m_fill_shade  = 0.55;
   m_texture_set = 0;
-  m_textures    = new GLuint[1];
 
   //m_back_img_b_ok = false;
   //m_back_img_b_on = false;
@@ -108,7 +107,6 @@ MarineViewer::MarineViewer(int x, int y, int w, int h, const char *l)
 
 MarineViewer::~MarineViewer()
 {
-   delete [] m_textures;
 }
 
 //-------------------------------------------------------------
@@ -416,12 +414,13 @@ bool MarineViewer::applyTiffFiles()
     return(false);
 
   unsigned int cnt = m_tif_files.size();
+  m_textures.resize(cnt);
   
   m_back_imgs = vector<BackImg>(cnt);
   
   glEnable(GL_TEXTURE_2D);
   glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
-  glGenTextures(cnt, m_textures);
+  glGenTextures(static_cast<GLsizei>(cnt), m_textures.data());
 
   for(unsigned int ix=0; ix<cnt; ix++) {
     m_back_imgs[ix].readTiff(m_tif_files[ix]);

--- a/ivp/src/lib_marineview/MarineViewer.h
+++ b/ivp/src/lib_marineview/MarineViewer.h
@@ -242,7 +242,7 @@ protected:
   double    m_datum_lon;
   
   bool      m_texture_init;
-  GLuint*   m_textures;
+  std::vector<GLuint> m_textures;
   int       m_texture_set;
 
   double    m_hash_shade;


### PR DESCRIPTION
## Summary

Fix a heap-buffer overflow when pMarineViewer is configured with multiple background TIFF files.

`MarineViewer` previously allocated space for only one OpenGL texture ID:

```cpp
m_textures = new GLuint[1];
```

However, `applyTiffFiles()` passes the full number of configured backgrounds to `glGenTextures()` and subsequently indexes one texture ID per background. With two or more backgrounds, OpenGL therefore writes beyond the one-element allocation.

This can corrupt adjacent heap memory, potentially causing crashes, incorrect rendering, or failures later in seemingly unrelated code.

The one-element allocation dates to 2007. Generalized support for multiple background images was added in 2022 without expanding the texture-ID storage.

## Change

Replace the manually allocated `GLuint` array with `std::vector<GLuint>` and resize it to the number of configured backgrounds before calling `glGenTextures()`.

This keeps all existing texture indexing and background-toggle behavior unchanged.

## Validation

- Full native macOS build passed.
- Full Ubuntu 24.04 ARM64/GCC 13 GUI build passed in a Linux VM.
- Launched separate pAntler missions with:
  - no background (`null.tif`)
  - one background
  - two distinct backgrounds
  - three distinct backgrounds
- Used the repository's `MIT_SP.tif`, `AerialMIT.tif`, and `forrest19.tif` images.
- Repeatedly cycled backgrounds with the backtick key:
  - one-image mission: 9 toggles
  - two-image mission: 12 toggles
  - three-image mission: 15 toggles
- Confirmed correct ordering and wraparound.
- Confirmed all pAntler processes shut down cleanly.
- Manually and visually verified that all three backgrounds rendered and toggled correctly.
- Confirmed the null/no-background case remains unchanged.
