### PR TITLE
Add quadcopter vehicle shape to pMarineViewer

### DIFF
--- a/ivp/src/lib_marineview/MarineViewer.cpp
+++ b/ivp/src/lib_marineview/MarineViewer.cpp
@@ -56,6 +56,7 @@
 #include "Shape_EField.h"
 #include "Shape_Square.h"
 #include "Shape_Skywalker.h"
+#include "Shape_Quadcopter.h"
 #include "Shape_Kelp.h"
 #include "XYFormatUtilsPoly.h"
 #include "BearingLine.h"
@@ -337,6 +338,8 @@ void MarineViewer::setVerbose(bool bval)
   m_verbose = bval;
   m_back_img.setVerbose(bval);
 }
+
+
 
 
 //-------------------------------------------------------------
@@ -972,6 +975,49 @@ void MarineViewer::drawCommonVehicle(const NodeRecord& record_mikerb,
     if(outer_line)
       drawGLPoly(g_skywBody, g_skywBodySize, white, outer_line, factor_x, transparency);    
     drawGLPoly(g_skywMid, g_skywMidSize, gray, 0, factor_x, transparency);
+    glTranslatef(cx, cy, 0);
+  }
+  else if(vehibody == "quadcopter") {
+    if(vlength > 0) {
+      factor_x *= (vlength / g_quadLength);
+      factor_y *= (vlength / g_quadLength);
+    }
+
+    ColorPack rotor_color(0.68, 0.71, 0.76);
+    ColorPack arm_color(0.43, 0.47, 0.53);
+    double cx = g_quadCtrX * factor_x;
+    double cy = g_quadCtrY * factor_y;
+    glTranslatef(-cx, -cy, 0);
+
+    drawGLPoly(g_quadArmA, g_quadArmASize, arm_color, 0,
+               factor_x, transparency);
+    drawGLPoly(g_quadArmB, g_quadArmBSize, arm_color, 0,
+               factor_x, transparency);
+
+    const double offsets[4][2] = {
+      {-g_quadRotorOffset, -g_quadRotorOffset},
+      { g_quadRotorOffset, -g_quadRotorOffset},
+      {-g_quadRotorOffset,  g_quadRotorOffset},
+      { g_quadRotorOffset,  g_quadRotorOffset}
+    };
+    for(unsigned int i=0; i<4; ++i) {
+      glTranslatef(offsets[i][0] * factor_x,
+                   offsets[i][1] * factor_y, 0);
+      drawGLPoly(g_quadRotor, g_quadRotorSize, rotor_color, 0,
+                 factor_x, transparency);
+      drawGLPoly(g_quadRotor, g_quadRotorSize, white, 1,
+                 factor_x, transparency);
+      glTranslatef(-offsets[i][0] * factor_x,
+                   -offsets[i][1] * factor_y, 0);
+    }
+
+    drawGLPoly(g_quadBody, g_quadBodySize, body_color, 0,
+               factor_x, transparency);
+    if(outer_line)
+      drawGLPoly(g_quadBody, g_quadBodySize, black, outer_line,
+                 factor_x, transparency);
+    drawGLPoly(g_quadHeading, g_quadHeadingSize, white, 0,
+               factor_x, transparency);
     glTranslatef(cx, cy, 0);
   }
   else if(vehibody == "heron") {

--- a/ivp/src/lib_marineview/MarineViewer.cpp
+++ b/ivp/src/lib_marineview/MarineViewer.cpp
@@ -977,7 +977,8 @@ void MarineViewer::drawCommonVehicle(const NodeRecord& record_mikerb,
     drawGLPoly(g_skywMid, g_skywMidSize, gray, 0, factor_x, transparency);
     glTranslatef(cx, cy, 0);
   }
-  else if(vehibody == "quadcopter") {
+  else if((vehibody == "quad") ||
+          (vehibody == "quadcopter")) {
     if(vlength > 0) {
       factor_x *= (vlength / g_quadLength);
       factor_y *= (vlength / g_quadLength);

--- a/ivp/src/lib_marineview/Shape_Quadcopter.h
+++ b/ivp/src/lib_marineview/Shape_Quadcopter.h
@@ -1,0 +1,100 @@
+/*****************************************************************/
+/*    NAME: Charles Benjamin                                     */
+/*    ORGN: Massachusetts Institute of Technology                */
+/*    FILE: Shape_Quadcopter.h                                   */
+/*    DATE: July 14th 2026                                       */
+/*                                                               */
+/* This file is part of MOOS-IvP                                 */
+/*                                                               */
+/* MOOS-IvP is free software: you can redistribute it and/or     */
+/* modify it under the terms of the GNU General Public License   */
+/* as published by the Free Software Foundation, either version  */
+/* 3 of the License, or (at your option) any later version.      */
+/*                                                               */
+/* MOOS-IvP is distributed in the hope that it will be useful,   */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty   */
+/* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See  */
+/* the GNU General Public License for more details.              */
+/*                                                               */
+/* You should have received a copy of the GNU General Public     */
+/* License along with MOOS-IvP.  If not, see                     */
+/* <http://www.gnu.org/licenses/>.                               */
+/*****************************************************************/
+
+#ifndef SHAPE_QUADCOPTER_HEADER
+#define SHAPE_QUADCOPTER_HEADER
+
+// MarineViewer treats +Y as the nose/forward direction. The two
+// rectangles form an X frame, with rotor centers at (+/-1.48,+/-1.48).
+double g_quadArmA[] =
+{
+  -1.56, -1.35,
+  -1.35, -1.56,
+   1.56,  1.35,
+   1.35,  1.56,
+  -1.56, -1.35
+};
+unsigned int g_quadArmASize = 5;
+
+double g_quadArmB[] =
+{
+  -1.56,  1.35,
+  -1.35,  1.56,
+   1.56, -1.35,
+   1.35, -1.56,
+  -1.56,  1.35
+};
+unsigned int g_quadArmBSize = 5;
+
+// One rotor disc centered on the origin. The renderer reuses it with
+// four translations, which avoids maintaining four duplicate arrays.
+double g_quadRotor[] =
+{
+   0.62,  0.00,
+   0.57,  0.24,
+   0.44,  0.44,
+   0.24,  0.57,
+   0.00,  0.62,
+  -0.24,  0.57,
+  -0.44,  0.44,
+  -0.57,  0.24,
+  -0.62,  0.00,
+  -0.57, -0.24,
+  -0.44, -0.44,
+  -0.24, -0.57,
+   0.00, -0.62,
+   0.24, -0.57,
+   0.44, -0.44,
+   0.57, -0.24,
+   0.62,  0.00
+};
+unsigned int g_quadRotorSize = 17;
+
+// The body takes the configured vehicle color. Its pointed front makes
+// heading readable even when the four rotors are visually symmetric.
+double g_quadBody[] =
+{
+  -0.76, -0.85,
+   0.76, -0.85,
+   0.76,  0.49,
+   0.00,  1.22,
+  -0.76,  0.49,
+  -0.76, -0.85
+};
+unsigned int g_quadBodySize = 6;
+
+double g_quadHeading[] =
+{
+  -0.26, 0.39,
+   0.26, 0.39,
+   0.00, 0.91,
+  -0.26, 0.39
+};
+unsigned int g_quadHeadingSize = 4;
+
+double g_quadRotorOffset = 1.48;
+double g_quadLength      = 4.20;
+double g_quadCtrX        = 0.0;
+double g_quadCtrY        = 0.0;
+
+#endif

--- a/ivp/src/lib_mbutil/MBUtils.cpp
+++ b/ivp/src/lib_mbutil/MBUtils.cpp
@@ -2612,7 +2612,7 @@ bool isKnownVehicleType(const string& vehicle_type)
      (vtype == "buoy") || (vtype == "heron")  || (vtype == "swimmer") ||
      (vtype == "cray") || (vtype == "bcray")  || (vtype == "crayx") ||
      (vtype == "wamv") || (vtype == "bcrayx") || (vtype == "smr") ||
-     (vtype == "skyw") || (vtype == "skywalker") ||
+     (vtype == "skyw") || (vtype == "skywalker") || (vtype == "quad") ||
      (vtype == "quadcopter")) {
     return(true);
   }

--- a/ivp/src/lib_mbutil/MBUtils.cpp
+++ b/ivp/src/lib_mbutil/MBUtils.cpp
@@ -2612,7 +2612,8 @@ bool isKnownVehicleType(const string& vehicle_type)
      (vtype == "buoy") || (vtype == "heron")  || (vtype == "swimmer") ||
      (vtype == "cray") || (vtype == "bcray")  || (vtype == "crayx") ||
      (vtype == "wamv") || (vtype == "bcrayx") || (vtype == "smr") ||
-     (vtype == "skyw") || (vtype == "skywalker")) {
+     (vtype == "skyw") || (vtype == "skywalker") ||
+     (vtype == "quadcopter")) {
     return(true);
   }
   


### PR DESCRIPTION
## Summary

- add a native top-down quadcopter vehicle shape to pMarineViewer
- render the configured vehicle color on the central body while retaining a high-contrast heading cue
- recognize both `quadcopter` and the shorthand `quad` as vehicle types

## Motivation

pMarineViewer includes a fixed-wing Skywalker icon but does not currently have a native multirotor icon. This adds a compact four-rotor shape that remains readable at mission-map scale and follows the existing polygon-based vehicle rendering approach.

## Validation

- completed a full `./build.sh -j8` build
- generated SIM, ArduCopter SITL, and real-hardware mission configurations using the new type
- live-tested `TYPE=quadcopter,COLOR=yellow` in pMarineViewer
- live-tested the `quad` alias with `COLOR=magenta` while the simulated vehicle was moving and rotating
