### PR TITLE
Preserve binary playback offsets as integers

### DIFF
--- a/MOOS_Jul2724/MOOSToolsUI/Tools/Graphical/uPlayBack/MOOSPlayBackV2.cpp
+++ b/MOOS_Jul2724/MOOSToolsUI/Tools/Graphical/uPlayBack/MOOSPlayBackV2.cpp
@@ -37,6 +37,7 @@
 
 #include "MOOSPlayBackV2.h"
 #include <algorithm>
+#include <cstdint>
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -285,8 +286,7 @@ bool CMOOSPlayBackV2::MessageFromLine(const std::string & sLine, CMOOSMsg &Msg)
         if(sData.find("<MOOS_BINARY>") !=std::string::npos)
         {
             //Msg.MarkAsBinary();
-            //long long nOffset;
-            double nOffset;
+            int64_t nOffset;
             if(!MOOSValFromString(nOffset,sData,"Offset"))
                 return MOOSFail("badly formed MOOS_BINARY indicator - missing \"Offset=xyz\"");
 


### PR DESCRIPTION
Replaces the double offset workaround with int64_t so binary log seeks retain exact large-file offsets. This is more reasonable now that we're committed to compiling against C++11. 

Corresponding upstream draft: https://github.com/moos-ivp/ui-moos/pull/2