### PR TITLE
Make BHV_TestFailure completion timing one-shot

### DIFF
--- a/ivp/src/lib_behaviors-marine/BHV_TestFailure.cpp
+++ b/ivp/src/lib_behaviors-marine/BHV_TestFailure.cpp
@@ -21,11 +21,10 @@
 /* <http://www.gnu.org/licenses/>.                               */
 /*****************************************************************/
 
-#include <cstdlib>
+#include <chrono>
 #include <assert.h>
 #include <cstdlib>
 #include "MBUtils.h"
-#include "MBTimer.h"
 #include "BHV_TestFailure.h"
 
 using namespace std;
@@ -39,6 +38,7 @@ BHV_TestFailure::BHV_TestFailure(IvPDomain gdomain) : IvPBehavior(gdomain)
 
   m_failure_crash = true;
   m_failure_burn  = false;
+  m_failure_triggered = false;
   m_failure_burn_time = 3;  // seconds
 }
 
@@ -76,22 +76,19 @@ bool BHV_TestFailure::setParam(string param, string val)
 
 void BHV_TestFailure::onCompleteState()
 {
+  if(m_failure_triggered)
+    return;
+
+  m_failure_triggered = true;
+
   if(m_failure_crash)
     assert(0);
   else if(m_failure_burn) {
-    MBTimer timer;
-    timer.start();
-    bool done = false;
-    while(!done) {
-      double elapsed_time = timer.get_float_wall_time();
-      if(elapsed_time > m_failure_burn_time)
-	done = true;
-    }
-    timer.stop();
+    const auto start_time = std::chrono::steady_clock::now();
+    while(std::chrono::duration<double>(std::chrono::steady_clock::now() -
+				       start_time).count() <= m_failure_burn_time) {}
   }
 }
-
-
 
 
 

--- a/ivp/src/lib_behaviors-marine/BHV_TestFailure.h
+++ b/ivp/src/lib_behaviors-marine/BHV_TestFailure.h
@@ -37,11 +37,11 @@ public:
  protected:
   bool   m_failure_crash;
   bool   m_failure_burn;
+  bool   m_failure_triggered;
   double m_failure_burn_time;
 };
 
 #endif
-
 
 
 


### PR DESCRIPTION
## Summary

- make `BHV_TestFailure` execute its requested crash or burn action only once
- measure burn duration with `std::chrono::steady_clock`
- preserve the existing crash, `hang` alias, default/malformed duration, and zero/negative duration behavior

## Problem

The zero-duration completion path can call `onCompleteState()` more than once for the same completed behavior. Since `BHV_TestFailure` performed the requested action on every call, `burn,2.0` stalled `pHelmIvP` for about four real seconds and the default three-second burn stalled it for about six.

The existing mission coverage only required some large iteration gap, so it did not distinguish the two- and three-second settings or detect the doubled duration. The strengthened harness now uses broad, non-overlapping duration bands and fails if a two-second burn behaves like a three-second burn (or vice versa).

## Validation

- full native macOS build on current `main`
- full build matrix: macOS native, Ubuntu GCC, Ubuntu Clang, Debian GCC, and Rocky Linux GCC (`5 passed, 0 failed`)
- `240/240` `behaviors-marine` CTests
- all `9/9` `BHV_TestFailure` mission cases at warp 10
- all four duration cases at warps 5, 10, and 20
- mutation check: changing the default three-second fixture to `burn,2.0` produces a mission-owned failure
- before the one-shot guard, `burn,2.0` measured a normalized helm gap near 400 at warp 10; afterward it measured near 200

The strengthened external harness is available in [cbenjamin23/moos-ivp-cicd-testing@f7a046cb](https://github.com/cbenjamin23/moos-ivp-cicd-testing/commit/f7a046cb).
