### PR TITLE
pMarineViewer: handle refresh_mode startup configuration

### DIFF
--- a/ivp/src/pMarineViewer/PMV_MOOSApp.cpp
+++ b/ivp/src/pMarineViewer/PMV_MOOSApp.cpp
@@ -870,6 +870,8 @@ void PMV_MOOSApp::handleStartUp(const MOOS_event & e) {
 
     else if(param == "content_mode") 
       handled = m_gui->setRadioCastAttrib(param, value);
+    else if(param == "refresh_mode")
+      handled = m_gui->setRadioCastAttrib(param, value);
     else if(param == "realmcast_channel")
 	handled = m_realm_repo->setOnStartPreferences(value);
     else if(param == "infocast_font_size") 
@@ -1479,4 +1481,3 @@ bool PMV_MOOSApp::buildReport()
   
   return(true);
 }
-


### PR DESCRIPTION
## Summary

Add startup configuration handling for the advertised `pMarineViewer`
`refresh_mode` parameter.

## Problem

`pMarineViewer --example` advertises:

```moos
refresh_mode = events  // {paused, streaming}
```

The GUI, validation, internal state, and runtime request logic already support
the `paused`, `events`, and `streaming` modes. However,
`PMV_MOOSApp::handleStartUp()` did not recognize `refresh_mode`, causing a
valid mission configuration line to be reported as unhandled.

No alternate `pMarineViewer` parameter provides this functionality.

## Change

Forward `refresh_mode` from the startup parser to the existing
`PMV_GUI::setRadioCastAttrib()` path.

This reuses the existing validation, GUI state synchronization, and AppCast and
RealmCast request behavior. It does not change the behavior of any refresh
mode.

## Validation

Validated using `moos-ivp-cicd-testing`:

- pMarineViewer refresh-mode unit test: 3/3 passed.
- Full Python CI suite: 90/90 passed.
- `apputil` CTest family: 28/28 passed.
- Repository invariants passed for all 67 registered harness targets.
- Full native macOS build passed.
- Full Ubuntu 24.04/GCC container build passed.
- `refresh_mode = paused` starts without a configuration warning.
- An invalid value such as `refresh_mode = bogus` remains rejected and reported
  as an unhandled configuration line.

## Scope

This is a focused startup-wiring fix. It does not introduce new refresh modes,
change existing runtime semantics, or add manual refresh functionality.
