### PR TITLE
pMarineViewer: fix advertised startup configuration parameters

### DIFF
--- a/ivp/src/pMarineViewer/PMV_Info.cpp
+++ b/ivp/src/pMarineViewer/PMV_Info.cpp
@@ -121,8 +121,7 @@ void showExampleConfigAndExit()
   blk("  grid_viewable_all        = true  // {TRUE, false}             ");
   blk("  grid_viewable_labels     = true  // {TRUE, false}             ");
   blk("  grid_opaqueness          = 0.3   // {0.1, 0.2, ..., 1.0}      ");
-  blk("  datum_viewable_all       = true  // {TRUE, false}             ");
-  blk("  datum_viewable_labels    = true  // {TRUE, false}             ");
+  blk("  datum_viewable           = true  // {TRUE, false}             ");
   blk("  marker_viewable_all      = true  // {TRUE, false}             ");
   blk("  marker_viewable_labels   = true  // {TRUE, false}             ");
   blk("  oparea_viewable_all      = true  // {TRUE, false}             ");
@@ -144,7 +143,7 @@ void showExampleConfigAndExit()
   blk("  vehicles_inactive_color = yellow // {red,white,blue,green}    ");
   blk("  trails_viewable         = true   // {TRUE, false}             ");
   blk("  trails_color            = white  // {WHITE, yellow, green}    ");
-  blk("  bearing_lines           = true   // {TRUE, false}             ");
+  blk("  bearing_lines_viewable  = true   // {TRUE, false}             ");
   blk("                                                                ");
   blk("  // InfoCasting Pull-Down Menu                                 ");
   blk("  infocast_viewable    = true     // {TRUE, false}              ");

--- a/ivp/src/pMarineViewer/PMV_MOOSApp.cpp
+++ b/ivp/src/pMarineViewer/PMV_MOOSApp.cpp
@@ -878,6 +878,14 @@ void PMV_MOOSApp::handleStartUp(const MOOS_event & e) {
       handled = m_gui->setRadioCastAttrib(param, value);
     else if(param == "realmcast_color_scheme") 
       handled = m_gui->setRadioCastAttrib(param, value);
+    else if((param == "realmcast_show_source")        ||
+	    (param == "realmcast_show_community")     ||
+	    (param == "realmcast_show_subscriptions") ||
+	    (param == "realmcast_show_masked")        ||
+	    (param == "realmcast_wrap_content")       ||
+	    (param == "realmcast_trunc_content")      ||
+	    (param == "realmcast_time_format_utc"))
+      handled = m_gui->setRadioCastAttrib(param, value);
     else if(param == "full_screen") 
       handled = m_gui->setRadioCastAttrib(param, value);
     else if(param == "infocast_viewable") 


### PR DESCRIPTION
## Context

This is a follow-up to #110, which wires the advertised `refresh_mode` setting into `pMarineViewer` startup configuration. While verifying that issue, we audited the other parameters printed by `pMarineViewer --example` for the same mismatch between advertised settings, existing implementation, and startup parsing.

That audit found seven RealmCast display settings with the same missing startup wiring, along with three stale or unsupported entries in the example configuration.

## Summary

- make the advertised RealmCast display settings (`realmcast_show_*`, `realmcast_wrap_content`, `realmcast_trunc_content`, and `realmcast_time_format_utc`) work when configured in the `pMarineViewer` mission block
- correct `pMarineViewer --example` to advertise the implemented `bearing_lines_viewable` and `datum_viewable` parameter names
- remove the `datum_viewable_labels` example because no such setting is implemented

## Problem

The RealmCast settings already had complete GUI setters, but the startup parser did not forward mission-file values to them. Two other example names had drifted from the names accepted by the underlying viewer settings, while the datum-label setting had no implementation.

As a result, valid-looking configuration copied from the example could be reported as unhandled and would not affect startup state.

## Impact

The advertised RealmCast display settings now work from the `pMarineViewer` mission block, and newly printed examples use the parameter names that the viewer actually implements.

## Validation

- focused source unit test covering all seven RealmCast routes and the canonical example entries
- full local build with `./build-ivp.sh -j4`
- verified `pMarineViewer --example` prints the corrected parameter names and omits the unsupported datum-label setting
