### PR TITLE
Fix uQueryDB --port

### DIFF
--- a/ivp/src/uQueryDB/QueryDB.cpp
+++ b/ivp/src/uQueryDB/QueryDB.cpp
@@ -60,7 +60,7 @@ bool QueryDB::setServerPort(string str)
   if(!isNumber(str))
     return(false);
 
-  m_sServerPort = atoi(str.c_str());
+  m_lServerPort = atoi(str.c_str());
   return(true);
 }
 
@@ -446,6 +446,5 @@ bool QueryDB::buildReport()
 
   return(true);
 }
-
 
 


### PR DESCRIPTION
## Summary

uQueryDB stores `--port` in `m_sServerPort` instead of the correct variable,
`m_lServerPort`. As a result:

```sh
uQueryDB --host=localhost --port=9105 ...
```

attempts to connect to `localhost:0`.

## Before

```cpp
m_sServerPort = atoi(str.c_str());
```

## After

```cpp
m_lServerPort = atoi(str.c_str());
```

`.moos` file connections do not use this setter and are unaffected.

## Validation

- Rebuilt `uQueryDB` successfully.
- The external `--port` regression passed 1/1.
- The existing `moos-ivp-cicd` uQueryDB matrix passed 32/32.
- No tests are added to the upstream MOOS-IvP repository.
