### PR TITLE
prototype spd regulation added to obstacle avoidance behavior

### DIFF
--- a/ivp/missions/s1_alpha_obsavoid/alpha.bhv
+++ b/ivp/missions/s1_alpha_obsavoid/alpha.bhv
@@ -66,7 +66,7 @@ Behavior = BHV_Waypoint
 }
 
 //----------------------------------------------
-Behavior = BHV_AvoidObstacleV21
+Behavior = BHV_AvoidObstacleV24
 {
   name       = avd_obs
   pwt        = 110

--- a/ivp/src/lib_behaviors-marine/BHV_AvoidObstacleV24.cpp
+++ b/ivp/src/lib_behaviors-marine/BHV_AvoidObstacleV24.cpp
@@ -162,6 +162,8 @@ bool BHV_AvoidObstacleV24::setParam(string param, string val)
 
   else if(param == "rng_flag")
     return(handleParamRangeFlag(val));
+  else if(param == "spd_regulate")
+    return(handleParamSpdRegulate(val));
   else if(param == "cpa_flag")
     return(addFlagOnString(m_cpa_flags, val));
   else if(param == "visual_hints")
@@ -221,6 +223,33 @@ bool BHV_AvoidObstacleV24::handleParamRangeFlag(string str)
     m_rng_thresh.push_back(thresh);
 
   return(true);
+}
+
+//-----------------------------------------------------------
+// Procedure: handleParamSpdRegulate()
+//   Example: min_spd=1, max_spd=11, max_discount=60
+
+bool BHV_AvoidObstacleV24::handleParamSpdRegulate(string str)
+{
+  double min_spd = -1;
+  double max_spd = -1;
+  double max_discount = -1;
+  
+  vector<string> svector = parseString(str, ',');
+  for(unsigned int i=0; i<svector.size(); i++) {
+    string param = biteStringX(svector[i],'=');
+    string value = svector[i];
+    if(param == "min_spd")
+      min_spd = atof(value.c_str());
+    else if(param == "max_spd")
+      max_spd = atof(value.c_str());
+    else if(param == "max_discount")
+      max_discount = atof(value.c_str());
+  }
+  bool ok = m_obship_model.setSpdRegulation(min_spd, max_spd,
+					    max_discount);
+
+  return(ok);
 }
 
 //-----------------------------------------------------------

--- a/ivp/src/lib_behaviors-marine/BHV_AvoidObstacleV24.h
+++ b/ivp/src/lib_behaviors-marine/BHV_AvoidObstacleV24.h
@@ -56,7 +56,8 @@ public:
   
  protected: 
   bool   handleParamRangeFlag(std::string);
-
+  bool   handleParamSpdRegulate(std::string);
+  
   double getRelevance();
   bool   updatePlatformInfo();
   void   postViewablePolygons();

--- a/ivp/src/lib_bhvutil/ObShipModelV24.cpp
+++ b/ivp/src/lib_bhvutil/ObShipModelV24.cpp
@@ -56,6 +56,10 @@ ObShipModelV24::ObShipModelV24(double osx, double osy,
 
   m_completed_dist = 50;
 
+  m_sreg_min_spd = -1;
+  m_sreg_max_spd = -1;
+  m_sreg_max_discount = -1;
+  
   // Set the precision for rounding/expanding the obstacle_buff
   // polygon. Affects the work involved for CPA calculations
   m_obuff_rdegs = 30;
@@ -159,6 +163,32 @@ void ObShipModelV24::setPlatModel(PlatModel plat_model)
 {
   m_plat_model = plat_model;
   m_stale_cache = true;
+}
+
+// ----------------------------------------------------------
+// Procedure: setSpdRegulation()
+
+bool ObShipModelV24::setSpdRegulation(double min_spd,
+				      double max_spd,
+				      double max_discount)
+{
+  // Ensure min/max spds are both >= 0
+  if((min_spd < 0) || (max_spd < 0))
+    return(false);
+
+  // Ensure the spd range is >= 0
+  if(min_spd >= max_spd)
+    return(false);
+
+  // Ensure the discount percent is between [0,100]
+  if((max_discount < 0) || (max_discount > 100))
+    return(false);
+
+  m_sreg_min_spd = min_spd;
+  m_sreg_max_spd = max_spd;
+  m_sreg_max_discount = max_discount;
+  
+  return(true);
 }
 
 // ----------------------------------------------------------
@@ -703,7 +733,12 @@ double ObShipModelV24::evalHdgSpd(double hdg, double spd,
     if(passing_side != m_passing_side)
       return(0);
   }
-    
+ 
+  // For evaluation of spd regulation use the average of the current
+  // vehicle speed and the candidate maneuver spd.
+  double eval_spd = (getOSV() + spd) / 2;
+  
+  vpct = spdRegulate(eval_spd); // mikerb Aug2526
   
   double min_util_cpa = vpct * m_min_util_cpa;
   double max_util_cpa = vpct * m_max_util_cpa;
@@ -959,6 +994,86 @@ bool ObShipModelV24::updateDynamic()
   
   return(true);
 }
+
+//-----------------------------------------------------------
+// Procedure: isSpdRegulated()
+
+bool ObShipModelV24::isSpdRegulated() const
+{
+  // Ensure min/max spds are both >= 0
+  if((m_sreg_min_spd < 0) || (m_sreg_max_spd < 0))
+    return(false);
+
+  // Ensure the spd range is >= 0
+  if(m_sreg_min_spd >= m_sreg_max_spd)
+    return(false);
+
+  // Ensure the discount percent is between [0,100]
+  if((m_sreg_max_discount < 0) || (m_sreg_max_discount > 100))
+    return(false);
+
+  return(true);
+}
+  
+//-----------------------------------------------------------
+// Procedure: spdRegulate()
+//   Returns: A value between [0.0, 1.0] b
+//  Examples: Given sreg_min=1, sreg_max=11, max_discount=50
+//         a: given_spd=6,  rval=0.75  (50%  of 50% = 25%.  1-0.25=0.75)
+//         b: given_spd=1,  rval=0.50  (100% of 50% = 50%.  1-0.50=0.50)
+//         d: given_spd=12, rval=1.00  (0%   of 50% = 0%.   1-0.00=1.00)
+//         d: given_spd=3,  rval=0.90  (80%  of 50% = 40%.  1-0.40=0.60)
+//         e: given_spd=9,  rval=0.90  (20%  of 50% = 10%.  1-0.10=0.90)
+// 
+//      Note: A return value of 1 indicates there is NO speed
+//            regulation.
+
+double ObShipModelV24::spdRegulate(double given_spd) const
+{
+  // Sanity check: Ensure spd regulation is enabled
+  if(!isSpdRegulated())
+    return(1);
+
+  // Sanity check: Recheck the range is >= 0 
+  double spd_range = m_sreg_max_spd - m_sreg_min_spd;
+  if(spd_range <= 0)
+    return(1);
+
+  // ----------------------------------------------------------------
+  // Part 1: Determine the percentage [0,1] of the available discount
+  // ----------------------------------------------------------------
+  double pct_discount = 0;  // Be conservative, no discount
+  // No discount
+  if(given_spd > m_sreg_max_spd)
+    pct_discount = 0;
+
+  // Full discount
+  if(given_spd < m_sreg_min_spd)
+    pct_discount = 1;
+
+  // Stuff in between no and full discount (0,1)
+  // eg sreg_max_spd=11 - given_spd=3. delta=8
+  double delta = m_sreg_max_spd - given_spd;  
+
+  // eg delta=8 / rng=10. pct_discount=0.8
+  pct_discount = delta / spd_range;           
+
+  // ----------------------------------------------------------------
+  // Part 2: Convert pct discount to pct of original full value
+  // ----------------------------------------------------------------
+  // eg pct=0.8 * 50% = 40%.
+  double applied_discount = pct_discount * m_sreg_max_discount; 
+
+  // eg 40% becomes 0.4
+  applied_discount = applied_discount / 100;
+
+  // eg a 10% (.1) discount meant 90% (0.9) of original value
+  // eg 0.1 becomes 0.9
+  double retval = 1 - applied_discount; 
+
+  return(retval);
+}
+  
 
 //-----------------------------------------------------------
 // Procedure: updateBngExtremes()

--- a/ivp/src/lib_bhvutil/ObShipModelV24.h
+++ b/ivp/src/lib_bhvutil/ObShipModelV24.h
@@ -53,6 +53,8 @@ class ObShipModelV24
   void   setPlatModel(PlatModel tm);
 
   void   setSideLock(bool v) {m_side_lock=v;}
+
+  bool   setSpdRegulation(double, double, double);
   
  public: // Setters that may generate health warnings
   std::string  setGutPoly(XYPolygon);
@@ -147,6 +149,9 @@ class ObShipModelV24
 
   void   updateBngExtremes();
 
+  bool   isSpdRegulated() const;
+  double spdRegulate(double) const;
+  
   std::string getVSource() const {return(m_gut_poly.get_vsource());}
   
 protected:
@@ -181,7 +186,11 @@ protected:
   bool   m_side_lock;
   
   std::set<std::string> m_set_params;
-  
+
+  double m_sreg_min_spd;      // m/s
+  double m_sreg_max_spd;      // m/s
+  double m_sreg_max_discount; // m/s
+
  private: // State (derived) variables
   XYPolygon m_mid_poly;
   XYPolygon m_rim_poly;


### PR DESCRIPTION
Speed regulation was added to the BHV_AvoidObstacleV24 behavior. Example config: 
spd_regulate = min_spd=0.4, max_spd=2, max_discount=80
Merged to allow wider testing. With out optional spd_regulate, behavior is unchanged.
