### PR TITLE
iSay: run the audio program without a shell

### DIFF
--- a/ivp/src/iSay/Sayer.cpp
+++ b/ivp/src/iSay/Sayer.cpp
@@ -23,6 +23,10 @@
 
 #include <cstdlib>
 #include <iterator>
+#include <vector>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include "MBUtils.h"
 #include "VoiceUtils.h"
 #include "fileutil.h"
@@ -297,6 +301,48 @@ bool Sayer::handleSetVolume(string volume)
 }
 
 //---------------------------------------------------------
+// Procedure: runNoShell()
+//   Purpose: Run a program with an explicit argument vector.  There is no
+//            shell involved, so nothing in the arguments can be interpreted
+//            as shell syntax.  The text spoken here arrives in a MOOS
+//            variable from any client, so it must never reach a shell.
+
+static bool runNoShell(const std::vector<std::string>& argv, bool background)
+{
+  if(argv.empty())
+    return(false);
+
+  pid_t pid = fork();
+  if(pid < 0)
+    return(false);
+
+  if(pid == 0) {
+    std::vector<char*> cargv;
+    for(unsigned int i=0; i<argv.size(); i++)
+      cargv.push_back(const_cast<char*>(argv[i].c_str()));
+    cargv.push_back(0);
+    execvp(cargv[0], &cargv[0]);
+    _exit(127);                       // exec failed
+  }
+
+  if(background) {
+    // Do not block, but do not leave a zombie either: this reaps whatever
+    // has finished since the last call.
+    int status = 0;
+    while(waitpid(-1, &status, WNOHANG) > 0)
+      ;
+    return(true);
+  }
+
+  int status = 0;
+  if(waitpid(pid, &status, 0) < 0)
+    return(false);
+
+  return(WIFEXITED(status) && (WEXITSTATUS(status) == 0));
+}
+
+
+//---------------------------------------------------------
 // Procedure: sayUtterance()
 //   Purpose: Process the top element in the queue
 
@@ -322,6 +368,11 @@ bool Sayer::sayUtterance()
   string srce  = utter.getSource();
   string text  = utter.getText();
   string file  = utter.getFile();
+
+  // The program and its arguments are kept apart so that no shell ever sees
+  // the text, which is published by any MOOS client.  cmd below is only used
+  // for the debug notification and the error message.
+  std::vector<std::string> argv;
   string cmd;
   //-------------------------------------------------
   // Case 1: Utterance is in the form of text
@@ -339,24 +390,33 @@ bool Sayer::sayUtterance()
     if(text != "")
       reportEvent("Say:" + text);
     
-    // Build the system command string (OSX)
+    // Build the argument vector (OSX)
     if((m_os_mode == "osx") || (m_os_mode == "both")) {
-      cmd  = "say -r " + str_rate;
-      if(voice != "")
-	cmd += " -v " + voice;
+      argv.push_back("say");
+      argv.push_back("-r");
+      argv.push_back(str_rate);
+      if(voice != "") {
+	argv.push_back("-v");
+	argv.push_back(voice);
+      }
 
       // Ex: $ say "[[volm 2]] Hello"
       if(m_volume != 1)
 	text = "[[volm " + doubleToStringX(m_volume) + "]] " + text;
 
-      cmd += " \"" + text + "\" ";
+      argv.push_back(text);
     }
-    // Build the system command string (Linux)
+    // Build the argument vector (Linux)
     else if((m_os_mode == "linux") || (m_os_mode == "both")) {
-      cmd = "espeak -s " + str_rate;
-      if(voice != "")
-	cmd += " -v " + voice;
-      cmd += "--stdin \"" + text + "\" ";
+      argv.push_back("espeak");
+      argv.push_back("-s");
+      argv.push_back(str_rate);
+      if(voice != "") {
+	argv.push_back("-v");
+	argv.push_back(voice);
+      }
+      argv.push_back("--stdin");
+      argv.push_back(text);
     }
 
   }
@@ -389,14 +449,18 @@ bool Sayer::sayUtterance()
       return(false);
     }
 
-    // Build the system command string (OSX)
+    // Build the argument vector (OSX)
     if((m_os_mode == "osx") || (m_os_mode == "both")) {
-      cmd = "afplay -v " + doubleToString(m_volume);
-      cmd += " " + found_file;
+      argv.push_back("afplay");
+      argv.push_back("-v");
+      argv.push_back(doubleToString(m_volume));
+      argv.push_back(found_file);
     }
-    // Build the system command string (Linux)
-    else if((m_os_mode == "linux") || (m_os_mode == "both"))
-      cmd = "aplay " + found_file;
+    // Build the argument vector (Linux)
+    else if((m_os_mode == "linux") || (m_os_mode == "both")) {
+      argv.push_back("aplay");
+      argv.push_back(found_file);
+    }
     
   }
   else {
@@ -404,19 +468,28 @@ bool Sayer::sayUtterance()
     return(false);
   }
 
-  // By adding an ampersand at the end of the command line, it runs the 
-  // job in the background thus returning immediately.
-  if(m_interval_policy == "from_start")
-    cmd += " &";
+  if(argv.empty()) {
+    reportRunWarning("No audio command configured for os_mode=" + m_os_mode);
+    return(false);
+  }
 
-  // We don't check the act on the result, but we get it anyway to avoid
-  // a compiler warning.
-  int result;
+  // A readable form of what is about to run, for the debug notification and
+  // the error message only.  It is never handed to a shell.
+  for(unsigned int i=0; i<argv.size(); i++) {
+    if(i > 0)
+      cmd += " ";
+    cmd += argv[i];
+  }
+
+  // The from_start policy used to append an ampersand so the shell would run
+  // the job in the background; without a shell that becomes "do not wait".
+  bool background = (m_interval_policy == "from_start");
+
   Notify("ISAY_DEBUGA", cmd);
-  result = system(cmd.c_str());
+  bool ok = runNoShell(argv, background);
   Notify("ISAY_DEBUGB", cmd);
 
-  if(result != 0) 
+  if(!ok) 
     cout << "Possible error in the iSay syscmd:" << cmd << endl;
 
   return(true);


### PR DESCRIPTION
# iSay: run the audio program without a shell

SAY_MOOS text is interpreted by a command shell

## Problem

`Sayer::sayUtterance()` (`ivp/src/iSay/Sayer.cpp:343-360, 416`) builds a shell
command line and runs it:

```
cmd  = "say -r " + str_rate;
cmd += " \"" + text + "\" ";
...
result = system(cmd.c_str());
```

`text` comes from `SAY_MOOS`, which any MOOS client can publish
(`Sayer.cpp:79-81`), and `Utterance::initFromString()`
(`ivp/src/iSay/Utterance.cpp:63-71`) stores a plain string verbatim with no
validation. Closing the quote and appending a command is enough. The audio file
branch is worse still: `found_file` is concatenated with no quoting at all.

## Impact

Arbitrary command execution as the user iSay runs as, from any client that can
reach the MOOSDB, with no authentication. On a vehicle that is the same account
the helm runs under.

## Fix

Keep the program and its arguments apart and never involve a shell:

* each branch fills a `std::vector<std::string> argv` instead of building a
  command line;
* a new `runNoShell()` helper forks and calls `execvp()` with that vector, so
  nothing in the arguments can be interpreted as syntax;
* the `from_start` interval policy used to append an ampersand for the shell to
  background the job. Without a shell that becomes "do not wait", and finished
  children are reaped on the next call so no zombies accumulate;
* `cmd` is still assembled, but only for the `ISAY_DEBUGA` notification and the
  error message.

## Files touched

* `ivp/src/iSay/Sayer.cpp`: add `runNoShell()`, build argument vectors, drop `system()`

## Evidence

Before, stock build of the unpatched revision:

```
$ python3 exploit.py 127.0.0.1 PORT
  RESULT: RCE SUCCEEDED
  uid=1001(ai) gid=1001(ai) groups=1001(ai),27(sudo),...
  iSay ALIVE
```

After, same test against this branch:

```
Same exploit against this branch:

  RESULT: no code execution
  iSay ALIVE
```

## Notes

`system()` was the only shell use on this path, so nothing else changes. The
Utterance parser is left alone deliberately: with no shell involved there is
nothing to escape, and restricting the spoken text would change what iSay is
for.
