### PR TITLE
uMemWatch: measure memory without a shell

### DIFF
--- a/ivp/src/uMemWatch/MemWatch.cpp
+++ b/ivp/src/uMemWatch/MemWatch.cpp
@@ -22,6 +22,14 @@
 /*****************************************************************/
 
 #include <cstdlib>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include <iterator>
 #include "MBUtils.h"
 #include "ACTable.h"
@@ -162,6 +170,66 @@ void MemWatch::handleMailDBClients(string clients)
 //---------------------------------------------------------
 // Procedure: measureMemory()
 
+//------------------------------------------------------------
+// Procedure: safeFileNamePart()
+//   Purpose: A client name arrives in DB_CLIENTS and is chosen by whoever
+//            connected to the MOOSDB.  It is used to build a file name here,
+//            so keep only characters which cannot mean anything to a shell,
+//            a path or an option parser.
+
+static std::string safeFileNamePart(const std::string& str)
+{
+  std::string out;
+  for(unsigned int i=0; i<str.length(); i++) {
+    char c = str[i];
+    if(((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) ||
+       ((c >= '0') && (c <= '9')) || (c == '_') || (c == '-') || (c == '.'))
+      out += c;
+  }
+  return(out);
+}
+
+//------------------------------------------------------------
+// Procedure: runToFile()
+//   Purpose: Run a program with an explicit argument vector, with its stdout
+//            redirected to the given file.  No shell is involved, so nothing
+//            in the arguments or in the file name can be interpreted as
+//            shell syntax.
+
+static bool runToFile(const std::vector<std::string>& argv,
+		      const std::string& outfile)
+{
+  if(argv.empty())
+    return(false);
+
+  pid_t pid = fork();
+  if(pid < 0)
+    return(false);
+
+  if(pid == 0) {
+    int fd = open(outfile.c_str(), O_WRONLY|O_CREAT|O_TRUNC, 0644);
+    if(fd < 0)
+      _exit(127);
+    if(dup2(fd, STDOUT_FILENO) < 0)
+      _exit(127);
+    close(fd);
+
+    std::vector<char*> cargv;
+    for(unsigned int i=0; i<argv.size(); i++)
+      cargv.push_back(const_cast<char*>(argv[i].c_str()));
+    cargv.push_back(0);
+    execvp(cargv[0], &cargv[0]);
+    _exit(127);
+  }
+
+  int status = 0;
+  if(waitpid(pid, &status, 0) < 0)
+    return(false);
+
+  return(WIFEXITED(status) && (WEXITSTATUS(status) == 0));
+}
+
+
 void MemWatch::measureMemory()
 {
   // Sanity check
@@ -177,10 +245,13 @@ void MemWatch::measureMemory()
   //         Make the system call
   string app = m_app[ix];
   string pid = m_pid[ix];
-  string tmp_file = ".mem_info_" + tolower(app) + "_" + pid;
-  string syscall = "appmem.sh --pid=" + m_pid[ix];
-  syscall += " > " + tmp_file;  
-  system(syscall.c_str());
+  string tmp_file = ".mem_info_" + safeFileNamePart(tolower(app)) + "_" +
+                    safeFileNamePart(pid);
+
+  std::vector<std::string> argv;
+  argv.push_back("appmem.sh");
+  argv.push_back("--pid=" + pid);
+  runToFile(argv, tmp_file);
 
   // Part 3: Get the output of the system call
   vector<string> lines = fileBuffer(tmp_file);
@@ -188,8 +259,7 @@ void MemWatch::measureMemory()
     return;
 
   // Part 4: Remove temporary file holding first sys call output
-  string syscall_rm = "rm -f " + tmp_file + " &";
-  system(syscall_rm.c_str());
+  remove(tmp_file.c_str());
   
   // Part 5: Intpret the output. Normall this is just an integer
   //         representing the mem size in Kilobytes. But we also


### PR DESCRIPTION
# uMemWatch: measure memory without a shell

uMemWatch constructs shell commands from spoofable client names

## Problem

`MemWatch::measureMemory()` (`ivp/src/uMemWatch/MemWatch.cpp:174-190`) builds
two shell command lines and runs them:

```
string tmp_file = ".mem_info_" + tolower(app) + "_" + pid;
string syscall = "appmem.sh --pid=" + m_pid[ix];
syscall += " > " + tmp_file;
system(syscall.c_str());
...
string syscall_rm = "rm -f " + tmp_file + " &";
system(syscall_rm.c_str());
```

`app` is a client name that arrived in `DB_CLIENTS`
(`handleMailDBClients()`, `:147-159`) and travelled through
`handleMailInfoPID()` (`:247-290`) with no grammar enforced anywhere. The
MOOSDB fills `DB_CLIENTS` from the names clients hand over during the handshake
and does not constrain them either.

## Impact

Arbitrary command execution as the user running uMemWatch, from an
unauthenticated MOOS connection plus one published double. A client named
`X;id>/tmp/pwned;` lands inside a shell redirection target and runs.

## Fix

* `measureMemory()` runs `appmem.sh` with an explicit argument vector through a
  new `runToFile()` helper, which forks, redirects stdout to the temporary file
  with `dup2()` and calls `execvp()`. No shell is involved, so nothing in the
  name or the pid can be interpreted.
* The temporary file is removed with `remove()` instead of
  `system("rm -f ... &")`.
* `safeFileNamePart()` strips anything from the app name that could mean
  something to a shell, a path or an option parser before it is used in a file
  name, so the name cannot escape the working directory either.

## Files touched

* `ivp/src/uMemWatch/MemWatch.cpp`: add `runToFile()` and `safeFileNamePart()`, drop both `system()` calls

## Evidence

Before, stock build of the unpatched revision:

```
$ python3 exploit.py 127.0.0.1 PORT
[*] publishing 'X;ID>/TMP/UMEMWATCH.PWNED;_PID' until the command runs
  RESULT: RCE SUCCEEDED
  uid=1001(ai) gid=1001(ai) groups=1001(ai),27(sudo),...
  uMemWatch ALIVE
```

After, same test against this branch:

```
Same exploit against this branch:

  RESULT: no code execution
  uMemWatch ALIVE
```

## Notes

The other half of this is that a MOOS client can choose any name at all, which
is what puts hostile bytes into `DB_CLIENTS` in the first place. A grammar and a
length limit on client identifiers in core-moos would stop this class of bug
reaching any consumer; that is a separate change to a different repository.
