### PR TITLE
uFldNodeComms: bind a node message to the community it came from

### DIFF
--- a/ivp/missions/u6_alpha/meta_shoreside.moos
+++ b/ivp/missions/u6_alpha/meta_shoreside.moos
@@ -122,6 +122,9 @@ ProcessConfig = uFldNodeComms
   MIN_MSG_INTERVAL = 20
   MAX_MSG_LENGTH   = 10
 
+  // pMarineViewer publishes NODE_MESSAGEs on behalf of vehicles.
+  BIND_MSG_SRC_TO_COMMUNITY = false
+
   GROUPS           = true
 }
 

--- a/ivp/missions/ufld_generic_sensor/meta_shoreside.moos
+++ b/ivp/missions/ufld_generic_sensor/meta_shoreside.moos
@@ -58,6 +58,8 @@ ProcessConfig = uFldNodeComms
         CRITICAL_RANGE = 25
       MIN_MSG_INTERVAL = 20
         MAX_MSG_LENGTH = 1000
+  // pMarineViewer publishes NODE_MESSAGEs on behalf of vehicles.
+  BIND_MSG_SRC_TO_COMMUNITY = false
                 GROUPS = true
   VIEW_NODE_RPT_PULSES = false
 }

--- a/ivp/src/uFldNodeComms/FldNodeComms.cpp
+++ b/ivp/src/uFldNodeComms/FldNodeComms.cpp
@@ -38,6 +38,11 @@ using namespace std;
 
 FldNodeComms::FldNodeComms()
 {
+  // A NODE_MESSAGE names the node it came from in its own body; require that
+  // to match the community the message arrived from.
+  m_bind_msg_src_to_community = true;
+  m_rejected_msg_source       = 0;
+
   // The default range within which reports are sent between nodes
   m_comms_range      = 100;
 
@@ -111,7 +116,7 @@ bool FldNodeComms::OnNewMail(MOOSMSG_LIST &NewMail)
     if((key == "NODE_REPORT") || (key == "NODE_REPORT_LOCAL")) 
       handled = handleMailNodeReport(sval, whynot);
     else if((key == "NODE_MESSAGE") || (key == "MEDIATED_MESSAGE"))
-      handled = handleMailNodeMessage(sval, msrc);
+      handled = handleMailNodeMessage(sval, msrc, msg.GetCommunity());
     else if(key == "ACK_MESSAGE") 
       handled = handleMailAckMessage(sval);
     else if(key == "UNC_SHARED_NODE_REPORTS") 
@@ -257,6 +262,8 @@ bool FldNodeComms::OnStartUp()
       handled = setNonNegDoubleOnString(m_min_msg_interval, value);
     else if(param == "min_rpt_interval") 
       handled = setNonNegDoubleOnString(m_min_rpt_interval, value);
+    else if(param == "bind_msg_src_to_community")
+      handled = setBooleanOnString(m_bind_msg_src_to_community, value);
     else if(param == "max_msg_length")
       handled = setUIntOnString(m_max_msg_length, value);
     else if(param == "stealth") 
@@ -329,7 +336,8 @@ bool FldNodeComms::handleMailNodeReport(const string& str, string& whynot)
 //                           var_name=FOO, string_val=bar   
 
 bool FldNodeComms::handleMailNodeMessage(const string& msg,
-					 const string& msg_src)
+					 const string& msg_src,
+					 const string& msg_community)
 {
   NodeMessage new_message = string2NodeMessage(msg);
   
@@ -347,6 +355,18 @@ bool FldNodeComms::handleMailNodeMessage(const string& msg,
   // then add it here. Added Mar 30, 2022.
   if(new_message.getSourceApp() == "")
     new_message.setSourceApp(msg_src);
+
+  // Part 3b: The src_node field decides which ledger entry the range,
+  // staleness and group checks below are evaluated against, and which node
+  // the recipient believes sent the message.  It is a field in the message
+  // body, so a publisher can put any node's name in it.  The community the
+  // message actually arrived from is set by the MOOSDB, so require the two to
+  // agree unless a deployment has turned that off.
+  if(m_bind_msg_src_to_community && (msg_community != "") &&
+     !MOOSStrCmp(new_message.getSourceNode(), msg_community)) {
+    m_rejected_msg_source++;
+    return(false);
+  }
 
   // Part 4: 
   string upp_src_node = new_message.getSourceNode();

--- a/ivp/src/uFldNodeComms/FldNodeComms.cpp
+++ b/ivp/src/uFldNodeComms/FldNodeComms.cpp
@@ -356,12 +356,7 @@ bool FldNodeComms::handleMailNodeMessage(const string& msg,
   if(new_message.getSourceApp() == "")
     new_message.setSourceApp(msg_src);
 
-  // Part 3b: The src_node field decides which ledger entry the range,
-  // staleness and group checks below are evaluated against, and which node
-  // the recipient believes sent the message.  It is a field in the message
-  // body, so a publisher can put any node's name in it.  The community the
-  // message actually arrived from is set by the MOOSDB, so require the two to
-  // agree unless a deployment has turned that off.
+  // Part 3b: Bind src_node to the MOOSDB community unless disabled.
   if(m_bind_msg_src_to_community && (msg_community != "") &&
      !MOOSStrCmp(new_message.getSourceNode(), msg_community)) {
     m_rejected_msg_source++;

--- a/ivp/src/uFldNodeComms/FldNodeComms.cpp
+++ b/ivp/src/uFldNodeComms/FldNodeComms.cpp
@@ -1127,6 +1127,9 @@ bool FldNodeComms::buildReport()
   m_msgs << "======================================" << endl;
 
   m_msgs << "    Total Msgs Received: " << m_total_messages_rcvd << endl;
+  if (m_bind_msg_src_to_community) {
+    m_msgs << "  Total Source-Rejected: " << m_rejected_msg_source << endl;
+  }
   map<string, unsigned int>::iterator q;
   for(q=m_map_messages_rcvd.begin(); q!=m_map_messages_rcvd.end(); q++) {
     string vname = q->first;

--- a/ivp/src/uFldNodeComms/FldNodeComms.h
+++ b/ivp/src/uFldNodeComms/FldNodeComms.h
@@ -51,7 +51,8 @@ class FldNodeComms : public AppCastingMOOSApp
  protected:
   void registerVariables();
   bool handleMailNodeReport(const std::string& str, std::string& whynot);
-  bool handleMailNodeMessage(const std::string& str, const std::string& src);
+  bool handleMailNodeMessage(const std::string& str, const std::string& src,
+			     const std::string& community);
   bool handleMailAckMessage(const std::string& str);
   bool handleMailCommsRange(double);
   bool handleStealth(const std::string&);
@@ -119,6 +120,13 @@ protected:
  
  protected: // State variables
   ContactLedger m_ledger;
+
+  // Must the src_node in a NODE_MESSAGE match the community the message
+  // actually came from?  A NODE_MESSAGE is relayed by the bridges, whose
+  // messages legitimately carry a foreign community, so this can be turned
+  // off for a deployment which relies on that.
+  bool          m_bind_msg_src_to_community;
+  unsigned int  m_rejected_msg_source;
   
   // Holds last time posted local share, if enabled, for each vname
   std::map<std::string, double>  m_map_lshare_tstamp;     


### PR DESCRIPTION
# uFldNodeComms: bind a node message to the community it came from

Spoofable node-message identities permit arbitrary cross-node notifications

## Problem

`FldNodeComms::handleMailNodeMessage()`
(`ivp/src/uFldNodeComms/FldNodeComms.cpp:331-352`) takes the sending node's
identity from the message body:

```
string upp_src_node = new_message.getSourceNode();
```

`distributeNodeMessageInfo()` (`:655-742`) then evaluates range, staleness and
group against that claimed identity's ledger entry, and the recipient's
`uFldMessageHandler` does `Notify(var_name, var_sval, src_node)`
(`ivp/src/uFldMessageHandler/MessageHandler.cpp:168-247`) with no allow-list on
`var_name`. `NodeMessage::valid()` (`ivp/src/lib_mbutil/NodeMessage.cpp:113-128`)
requires only a non-empty `src_node`, some destination, and a non-empty
`var_name`.

## Impact

Any field publisher can send

```
src_node=alpha,dest_node=bravo:charlie,var_name=MOOS_MANUAL_OVERRIDE,string_val="false"
```

and have the shore relay it to both vehicles as though alpha had sent it, so it
can clear a manual override, deploy, return or abort, and the action is logged
against another node.

## Fix

The community a message arrived from is set by the MOOSDB, not by the publisher's
payload, so it is the field to key on. Pass it into
`handleMailNodeMessage()` and require `src_node` to match it; a mismatch is
counted and the message dropped.

`bind_msg_src_to_community`, default true, turns the check off for a deployment
that relies on a relay forwarding messages on behalf of other communities.

## Files touched

* `ivp/src/uFldNodeComms/FldNodeComms.h`: carry the community into the handler, add the flag and a reject counter
* `ivp/src/uFldNodeComms/FldNodeComms.cpp`: require `src_node` to match the originating community

## Evidence

Before, stock build of the unpatched revision:

```
A publisher whose own community is not alpha, claiming src_node=alpha:

  NODE_MESSAGE = src_node=alpha,dest_node=bravo:charlie,
                 var_name=MOOS_MANUAL_OVERRIDE,string_val="false"

  NODE_MESSAGE_BRAVO     relayed: ['src_node=alpha,...,string_val="false"']
  NODE_MESSAGE_CHARLIE   relayed: ['src_node=alpha,...,string_val="false"']
```

After, same test against this branch:

```
Same message against this branch:

  NODE_MESSAGE_BRAVO     relayed: []
  NODE_MESSAGE_CHARLIE   relayed: []

A publisher whose community IS alpha, same message shape, is still relayed on
both versions:

  unpatched: relayed with a matching community: YES
  patched:   relayed with a matching community: YES
```

## Notes

This is only as strong as the MOOSDB's community field. Today a client can set
that field itself, so the check should be read together with binding message
provenance to the connection in core-moos, which is reported separately; with
that in place this check is decisive, and without it the attacker at least has
to claim the victim's community rather than simply naming it in a body field.

The missing allow-list on `var_name` in `uFldMessageHandler` is a separate
problem and is not addressed here: any default list would have to enumerate what
every mission legitimately sends between vehicles.
