### PR TITLE
uFldShoreBroker: refuse a ping whose keyword does not match

### DIFF
--- a/ivp/src/uFldShoreBroker/ShoreBroker.cpp
+++ b/ivp/src/uFldShoreBroker/ShoreBroker.cpp
@@ -385,8 +385,19 @@ void ShoreBroker::handleMailNodePing(const string& info)
     reportRunWarning(status);
   }
     
-  if((m_keyword != "") && (m_keyword != hrecord.getKeyword()))
+  if((m_keyword != "") && (m_keyword != hrecord.getKeyword())) {
+    // A ping carries the pShare input routes this broker will be told to
+    // send to, so enrolling a node whose keyword does not match means
+    // bridging mission traffic to an address chosen by the sender.  When a
+    // keyword is configured, a mismatch is a refusal, not a status string.
     status = "keyword_mismatch";
+    hrecord.setStatus(status);
+    reportRunWarning("Refused NODE_BROKER_PING from " +
+		     hrecord.getCommunity() + ": " + status);
+    reportEvent("Refused ping from " + hrecord.getCommunity() +
+		" (keyword mismatch)");
+    return;
+  }
   hrecord.setStatus(status);
 
   string ping_time = hrecord.getTimeStamp();


### PR DESCRIPTION
# uFldShoreBroker: refuse a ping whose keyword does not match

ShoreBroker trusts claimed node pings to create outbound bridge routes

## Problem

`ShoreBroker::handleMailNodePing()`
(`ivp/src/uFldShoreBroker/ShoreBroker.cpp:369-463`) compares the configured
keyword against the one in the incoming `NODE_BROKER_PING`, but a mismatch only
writes a status string:

```
if((m_keyword != "") && (m_keyword != hrecord.getKeyword()))
  status = "keyword_mismatch";
hrecord.setStatus(status);
```

The node is enrolled regardless, and `makeBridgeRequestAll()` / `makeBridgeRequest()`
(`:502-554`) then emit `PSHARE_CMD` `cmd=output` entries whose `route=` comes
from the ping's `pshare_iroutes`. `HostRecord::valid()`
(`ivp/src/lib_ufield/HostRecord.cpp:92-110`) checks only that the community is
non-empty, the IP parses and the DB port is numeric, and
`string2HostRecord()` (`ivp/src/lib_ufield/HostRecordUtils.cpp:35-70`) silently
ignores fields it does not recognise.

## Impact

One unauthenticated `NODE_BROKER_PING` has the shore bridge `DEPLOY_ALL`,
`RETURN_ALL`, `APPCAST_REQ`, `REALMCAST_REQ` and the mission hash to an address
the sender chose, while announcing itself as a node of the mission. The keyword
is the only admission control uFldShoreBroker has.

## Fix

When a keyword is configured and the ping does not carry it, refuse the ping:
report a run warning and an event naming the community, and return before the
node is enrolled. Behaviour with no keyword configured, and with a matching
keyword, is unchanged.

## Files touched

* `ivp/src/uFldShoreBroker/ShoreBroker.cpp`: treat a keyword mismatch as a refusal rather than a status string

## Evidence

Before, stock build of the unpatched revision:

```
One ping with a deliberately wrong keyword, against a shore configured with
keyword = fleet-secret:

  [2] PSHARE_CMD output routes the shore created for us: 8
        cmd=output,src_name=DEPLOY_ALL,dest_name=DEPLOY,route=127.0.0.1:19997
        cmd=output,src_name=REALMCAST_REQ_ALL,dest_name=REALMCAST_REQ,route=127.0.0.1:19997
        cmd=output,src_name=NODE_BROKER_ACK_PIRATE6357,dest_name=NODE_BROKER_ACK,route=127.0.0.1:19997
        ...
```

After, same test against this branch:

```
Same ping against this branch:

  [2] PSHARE_CMD output routes the shore created for us: 0

  uFldShoreBroker: Refused NODE_BROKER_PING from pirate6357: keyword_mismatch

A ping carrying the correct keyword is still enrolled, on both versions:

  unpatched: PSHARE_CMD routes for a correct-keyword ping: 7
  patched:   PSHARE_CMD routes for a correct-keyword ping: 7
```

## Notes

This makes the keyword mean something; it does not make it a good credential. It
travels in cleartext in every ping, and the community field the broker keys on
is itself attacker chosen unless the MOOSDB binds it to the connection. Both of
those are reported separately.
