### PR TITLE
Bound the BHV_IPF decoder copies and scans

### DIFF
--- a/ivp/src/lib_ivpbuild/FunctionEncoder.cpp
+++ b/ivp/src/lib_ivpbuild/FunctionEncoder.cpp
@@ -297,21 +297,30 @@ IvPFunction *StringToIvPFunction(const string& str)
 
   int cix = 2; // To account for the H, in the header
 
+  // Every field below is read from a MOOS variable, so the string may end at
+  // any point and any field may be longer than the buffer it is copied into.
+  // slen bounds every scan; the copies below bound themselves.
+  const int slen = (int)str.length();
+
   // Determine the length of the context string
   int cstr_len = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     cstr_len = cstr_len * 10;
     cstr_len += (int)(str[cix]-48);
     cix++;
   }
   cix++;
 
-  // Determine the context string, if any
+  // Determine the context string, if any.  cstr_len is the declared length,
+  // i.e. the capacity of the buffer; the field itself may be longer, so copy
+  // only what fits and skip the rest rather than running off the end.
+  if(cstr_len < 0)
+    return(0);
   char *cstr_buff = new char[cstr_len+10];
   int  cbix = 0;
-  while(str[cix] != ',') {
-    cstr_buff[cbix] = str[cix];
-    cbix++;
+  while((cix < slen) && (str[cix] != ',')) {
+    if(cbix < cstr_len)
+      cstr_buff[cbix++] = str[cix];
     cix++;
   }
   cstr_buff[cbix] = '\0';
@@ -319,7 +328,7 @@ IvPFunction *StringToIvPFunction(const string& str)
 
   // Determine the number of dimensions
   int dim = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     dim = dim * 10;
     dim += (int)(str[cix]-48);
     cix++;
@@ -328,7 +337,7 @@ IvPFunction *StringToIvPFunction(const string& str)
 
   // Determine the number of pieces
   int pcs = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     pcs = pcs * 10;
     pcs += (int)(str[cix]-48);
     cix++;
@@ -337,7 +346,7 @@ IvPFunction *StringToIvPFunction(const string& str)
    
   // Determine the degree
   int deg = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     deg = deg * 10;
     deg += (int)(str[cix]-48);
     cix++;
@@ -348,7 +357,7 @@ IvPFunction *StringToIvPFunction(const string& str)
   double pwt  = 0.0;
   double frac = 0.1;
   bool   left_of_decimal = true;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     if(str[cix] == '.') {
       left_of_decimal = false;
     }
@@ -370,11 +379,13 @@ IvPFunction *StringToIvPFunction(const string& str)
   cix += 2;
   char buff[5000];
   int  bix = 0;
-  while(str[cix] != ',') {
-    buff[bix] = str[cix];
-    if(buff[bix] == ';')
-      buff[bix] = ',';
-    bix++;
+  while((cix < slen) && (str[cix] != ',')) {
+    if(bix < (int)sizeof(buff)-1) {
+      buff[bix] = str[cix];
+      if(buff[bix] == ';')
+        buff[bix] = ',';
+      bix++;
+    }
     cix++;
   }
   buff[bix] = '\0';
@@ -394,7 +405,7 @@ IvPFunction *StringToIvPFunction(const string& str)
   for(d=0; d<dim; d++) {
     // Determine the grid length for this dimension
     int val = 0;
-    while(str[cix] != ',') {
+    while((cix < slen) && (str[cix] != ',')) {
       val = val * 10;
       val += (int)(str[cix]-48);
       cix++;
@@ -419,7 +430,7 @@ IvPFunction *StringToIvPFunction(const string& str)
 
       // Determine the low value
       int low = 0;
-      while(str[cix] != ',') {
+      while((cix < slen) && (str[cix] != ',')) {
 	low = low * 10;
 	low += (int)(str[cix]-48);
 	cix++;
@@ -433,7 +444,7 @@ IvPFunction *StringToIvPFunction(const string& str)
       }
       // Determine the high value
       int hgh = 0;
-      while(str[cix] != ',') {
+      while((cix < slen) && (str[cix] != ',')) {
 	hgh = hgh * 10;
 	hgh += (int)(str[cix]-48);
 	cix++;
@@ -500,21 +511,28 @@ string StringToIvPContext(const string& str)
 {
   int cix = 2; // To account for the H, in the header
 
+  // as in StringToIvPFunction(): the string may end at any point, and the
+  // declared length is the capacity, not a promise about the field
+  const int slen = (int)str.length();
+
   // Determine the length of the context string
   int cstr_len = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     cstr_len = cstr_len * 10;
     cstr_len += (int)(str[cix]-48);
     cix++;
   }
   cix++;
 
+  if(cstr_len < 0)
+    return("");
+
   // Determine the context string, if any
   char *cstr_buff = new char[cstr_len+10];
   int  cbix = 0;
-  while(str[cix] != ',') {
-    cstr_buff[cbix] = str[cix];
-    cbix++;
+  while((cix < slen) && (str[cix] != ',')) {
+    if(cbix < cstr_len)
+      cstr_buff[cbix++] = str[cix];
     cix++;
   }
   cstr_buff[cbix] = '\0';
@@ -532,22 +550,29 @@ IvPDomain IPFStringToIvPDomain(const string& str)
 {
   int cix = 2; // To account for the H, in the header
 
+  // as elsewhere in this file: the header comes from a MOOS variable and may
+  // end at any point, so every scan has to stop at the end of the string
+  const int slen = (int)str.length();
+
   // Determine the length of the context string
   int cstr_len = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     cstr_len = cstr_len * 10;
     cstr_len += (int)(str[cix]-48);
     cix++;
   }
   cix++;
 
-  while(str[cix] != 'D')
+  while((cix < slen) && (str[cix] != 'D'))
     cix++;
   cix += 2;
   
   int cixx = cix;
-  while(str[cixx] != ',')
+  while((cixx < slen) && (str[cixx] != ','))
     cixx++;
+
+  if(cix > slen)
+    return(IvPDomain());
 
   string domain_str = str.substr(cix, cixx-cix);
   domain_str = findReplace(domain_str, ';', ',');

--- a/ivp/src/lib_ivpbuild/FunctionEncoderMK.cpp
+++ b/ivp/src/lib_ivpbuild/FunctionEncoderMK.cpp
@@ -296,21 +296,27 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
   const char *cstr = str.c_str();
   cstr += 2; // to account for H, in the header
 
+  // Every scan below is of the form while(*cstr != ','), which does not stop
+  // at the terminating NUL, so each one needs an explicit end-of-string test.
+
   // Determine the length of the context string
   int cstr_len = 0;
-  while(*cstr != ',') {
+  while((*cstr != ',') && (*cstr != '\0')) {
     cstr_len = cstr_len * 10;
     cstr_len += (int)(*cstr-48);
     ++cstr;
   }
   ++cstr;
 
-  // Determine the context string, if any
+  // Determine the context string, if any.  cstr_len is the declared length,
+  // i.e. the capacity of the buffer, so copy only what fits.
+  if(cstr_len < 0)
+    return(0);
   char *cstr_buff = new char[cstr_len+10];
   int  cbix = 0;
-  while(*cstr != ',') {
-    cstr_buff[cbix] = *cstr;
-    cbix++;
+  while((*cstr != ',') && (*cstr != '\0')) {
+    if(cbix < cstr_len)
+      cstr_buff[cbix++] = *cstr;
     ++cstr;
   }
   cstr_buff[cbix] = '\0';
@@ -318,7 +324,7 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
 
   // Determine the number of dimensions
   int dim = 0;
-  while(*cstr != ',') {
+  while((*cstr != ',') && (*cstr != '\0')) {
     dim = dim * 10;
     dim += (int)(*cstr-48);
     ++cstr;
@@ -327,7 +333,7 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
 
   // Determine the number of pieces
   int pcs = 0;
-  while(*cstr != ',') {
+  while((*cstr != ',') && (*cstr != '\0')) {
     pcs = pcs * 10;
     pcs += (int)(*cstr-48);
     ++cstr;
@@ -336,7 +342,7 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
    
   // Determine the degree
   int deg = 0;
-  while(*cstr != ',') {
+  while((*cstr != ',') && (*cstr != '\0')) {
     deg = deg * 10;
     deg += (int)(*cstr-48);
     ++cstr;
@@ -347,7 +353,7 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
   double pwt  = 0.0;
   double frac = 0.1;
   bool   left_of_decimal = true;
-  while(*cstr != ',') {
+  while((*cstr != ',') && (*cstr != '\0')) {
     if(*cstr == '.') {
       left_of_decimal = false;
     }
@@ -369,11 +375,13 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
   cstr += 2;
   char buff[5000];
   int  bix = 0;
-  while(*cstr != ',') {
-    buff[bix] = *cstr;
-    if(buff[bix] == ';')
-      buff[bix] = ',';
-    bix++;
+  while((*cstr != ',') && (*cstr != '\0')) {
+    if(bix < (int)sizeof(buff)-1) {
+      buff[bix] = *cstr;
+      if(buff[bix] == ';')
+        buff[bix] = ',';
+      bix++;
+    }
     ++cstr;
   }
   buff[bix] = '\0';
@@ -387,7 +395,7 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
   for(d=0; d<dim; d++) {
     // Determine the grid length for this dimension
     int val = 0;
-    while(*cstr != ',') {
+    while((*cstr != ',') && (*cstr != '\0')) {
       val = val * 10;
       val += (int)(*cstr-48);
       ++cstr;
@@ -412,7 +420,7 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
 
       // Determine the low value
       int low = 0;
-      while(*cstr != ',') {
+      while((*cstr != ',') && (*cstr != '\0')) {
 	low = low * 10;
 	low += (int)(*cstr-48);
 	++cstr;
@@ -426,7 +434,7 @@ IvPFunction *StringToIvPFunctionMK(const string& str)
       }
       // Determine the high value
       int hgh = 0;
-      while(*cstr != ',') {
+      while((*cstr != ',') && (*cstr != '\0')) {
 	hgh = hgh * 10;
 	hgh += (int)(*cstr-48);
 	++cstr;


### PR DESCRIPTION
# Bound the BHV_IPF decoder copies and scans

IvP string decoders copy attacker-controlled fields beyond heap and stack buffers

## Problem

The `BHV_IPF` decoder in `ivp/src/lib_ivpbuild/FunctionEncoder.cpp` is a hand
written parser with no bounds of any kind, and `BHV_IPF` is an ordinary MOOS
variable that any client can publish.

* `StringToIvPFunction()` (`:298-311`) and `StringToIvPContext()` (`:499-524`)
  allocate the context buffer as `new char[cstr_len+10]`, where `cstr_len` is a
  number in the payload, and then copy the field with a loop that runs to the
  next comma. Declaring a short length and supplying a long field is a heap
  overflow whose size the publisher chooses.
* The domain field is copied into `char buff[5000]` (`:366-378`) with no bound
  at all.
* Every field is scanned with `while(str[cix] != ',')` (`:300-505`), which walks
  past the end of the `std::string` when a delimiter is missing.

The same defects are duplicated in `FunctionEncoderMK.cpp` (`:292-380`), where
the loops are `while(*cstr != ',')` and so do not stop at the terminating NUL
either.

Consumers: `uFunctionVis` (`ivp/src/uFunctionVis/FV_MOOSApp.cpp:63-66, 125`),
`IPF_Entry` (`ivp/src/lib_ipfview/IPF_Entry.cpp:48, 66`) and `alogview`
(`ivp/src/app_alogview/IvPFuncViewerX.cpp:439, 537`).

## Impact

A fully controlled heap overflow and a stack overflow in the operator's function
viewer, driven by an unauthenticated MOOS publisher. A 4 KB `BHV_IPF` value
crashes a stock `uFunctionVis`. The same decoder runs on stored log contents, so
a log file is an offline delivery path for the same primitive.

## Fix

* Both context copies are bounded by the declared length, which is the capacity
  actually allocated. A longer field is truncated and its remainder skipped, so
  the parse stream stays in sync rather than desynchronising.
* The domain copy is bounded by `sizeof(buff)`.
* Every scan loop stops at the end of the string, in both files.
* A negative declared length is refused instead of being passed to `new[]`.

## Files touched

* `ivp/src/lib_ivpbuild/FunctionEncoder.cpp`: bounded copies and scans in `StringToIvPFunction()`, `StringToIvPContext()` and `IPFStringToIvPDomain()`
* `ivp/src/lib_ivpbuild/FunctionEncoderMK.cpp`: the same in the duplicated decoder

## Evidence

Before, stock build of the unpatched revision:

```
Three payload shapes against a live uFunctionVis: a 4 KB context overflow, a
20 KB domain overflow and a 12 byte truncated header.

  Segmentation fault (core dumped)
  RESULT: uFunctionVis DEAD

Sanitised build:
  FunctionEncoder.cpp:516:21: runtime error: store to address ... with
      insufficient space for an object of type 'char'
  ERROR: AddressSanitizer: heap-buffer-overflow, WRITE of size 1
      #0 in StringToIvPContext(std::string const&)  FunctionEncoder.cpp:516

  FunctionEncoder.cpp:374:13: runtime error: index 5000 out of bounds for
      type 'char [5000]'
  ERROR: AddressSanitizer: stack-buffer-overflow, WRITE of size 1
      #0 in StringToIvPFunction(std::string const&)  FunctionEncoder.cpp:374
```

After, same test against this branch:

```
Same three shapes against this branch:

  all three payloads consumed
  RESULT: uFunctionVis ALIVE
```

## Notes

`FunctionEncoderMK.cpp` has no callers in the tree today. It is patched anyway
because it is a copy of the same parser and would carry the same defects the
moment it is wired up.

Two further problems in the same decoder are reported separately: the counts in
the payload are unchecked before being used as allocation sizes, and
`StringToIvPContext()` leaks its buffer.
