### PR TITLE
Validate the counts a BHV_IPF payload declares about itself

### DIFF
--- a/ivp/src/lib_ivpbuild/FunctionEncoder.cpp
+++ b/ivp/src/lib_ivpbuild/FunctionEncoder.cpp
@@ -297,6 +297,10 @@ IvPFunction *StringToIvPFunction(const string& str)
 
   int cix = 2; // To account for the H, in the header
 
+  // the payload arrives in a MOOS variable, so its length is the only honest
+  // upper bound on anything the payload declares about itself
+  const int slen = (int)str.length();
+
   // Determine the length of the context string
   int cstr_len = 0;
   while(str[cix] != ',') {
@@ -319,27 +323,39 @@ IvPFunction *StringToIvPFunction(const string& str)
 
   // Determine the number of dimensions
   int dim = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     dim = dim * 10;
     dim += (int)(str[cix]-48);
+    if(dim > slen) {          // cannot be honest, and stops the int overflowing
+      delete [] cstr_buff;
+      return(0);
+    }
     cix++;
   }
   cix++;
 
   // Determine the number of pieces
   int pcs = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     pcs = pcs * 10;
     pcs += (int)(str[cix]-48);
+    if(pcs > slen) {          // cannot be honest, and stops the int overflowing
+      delete [] cstr_buff;
+      return(0);
+    }
     cix++;
   }
   cix++;
    
   // Determine the degree
   int deg = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     deg = deg * 10;
     deg += (int)(str[cix]-48);
+    if(deg > slen) {          // cannot be honest, and stops the int overflowing
+      delete [] cstr_buff;
+      return(0);
+    }
     cix++;
   }
   cix++;
@@ -401,6 +417,22 @@ IvPFunction *StringToIvPFunction(const string& str)
     }
     cix++;
     gelbox.setPTS(d,0,val);
+  }
+
+  // dim, pcs and deg all arrive in the payload, accumulated digit by digit
+  // with no ceiling, and are then used as allocation sizes and loop bounds:
+  // PDMap allocates new IvPBox*[pcs], each IvPBox allocates arrays of dim and
+  // of (deg*dim)+1, and IvPBox narrows the dimension to a short int on the
+  // way.  Check them against something before any of that happens.
+  //
+  // The bound on pcs is the length of the payload itself: every piece has to
+  // contribute at least a low bound, a high bound and a coefficient, so a
+  // string of slen bytes cannot honestly describe more than slen pieces.
+  if((dim < 1) || (dim > MAX_IPF_DIMENSIONS) ||
+     (deg < 0) || (deg > MAX_IPF_DEGREE) ||
+     (pcs < 1) || (pcs > slen)) {
+    delete [] cstr_buff;
+    return(0);
   }
 
   // Build the PDMap

--- a/ivp/src/lib_ivpbuild/FunctionEncoder.h
+++ b/ivp/src/lib_ivpbuild/FunctionEncoder.h
@@ -30,6 +30,12 @@
 #include "IvPFunction.h"
 
 // Convert an IvPFunction to string represntation
+// Ceilings on what a serialised IvP function may declare about itself.  Both
+// figures are far above any real function: IvP domains are one to three
+// dimensions and the pieces are linear or quadratic.
+#define MAX_IPF_DIMENSIONS 16
+#define MAX_IPF_DEGREE     8
+
 std::string IvPFunctionToString(IvPFunction*);
 
 // Convert an IvPFunction to a vector of strings

--- a/ivp/src/lib_ivpcore/IvPBox.cpp
+++ b/ivp/src/lib_ivpcore/IvPBox.cpp
@@ -42,6 +42,13 @@ using namespace std;
 
 IvPBox::IvPBox(int g_dim, int g_degree)
 {
+  // m_dim and m_degree are short ints, so a large g_dim silently becomes a
+  // small or negative dimension and the arrays below are never allocated
+  // while the caller still writes through them.  Treat anything which does
+  // not survive the narrowing as an empty box.
+  if((g_dim < 0) || (g_dim > 32767) || (g_degree < 0) || (g_degree > 32767))
+    g_dim = g_degree = 0;
+
   m_dim     = (short int) g_dim;
   m_degree  = (short int) g_degree;
   m_pts     = 0;

--- a/ivp/src/lib_ivpcore/PDMap.cpp
+++ b/ivp/src/lib_ivpcore/PDMap.cpp
@@ -58,6 +58,10 @@ PDMap::PDMap(int g_boxCount, const IvPDomain& g_domain, int g_degree)
 {
   assert(g_degree >= 0);
 
+  // a negative count would be passed straight to new IvPBox*[]
+  if(g_boxCount < 0)
+    g_boxCount = 0;
+
   m_boxCount = g_boxCount;
   m_domain   = g_domain;
   m_degree   = g_degree;


### PR DESCRIPTION
# Validate the counts a BHV_IPF payload declares about itself

IvP dimensions, degrees, and piece counts control unchecked allocations and loops

## Problem

`StringToIvPFunction()` (`ivp/src/lib_ivpbuild/FunctionEncoder.cpp:295-405`)
reads `dim`, `pcs` and `deg` out of the `BHV_IPF` payload with
`x = x*10 + (str[cix]-48)` and then uses them as allocation sizes and loop
bounds with no check:

* `PDMap`'s constructor (`ivp/src/lib_ivpcore/PDMap.cpp:57-74`) does
  `new IvPBox *[m_boxCount]` with `pcs` straight from the wire.
* Each `IvPBox` (`ivp/src/lib_ivpcore/IvPBox.cpp:43-71`) allocates arrays of
  `dim*2` and of `(deg*dim)+1`.
* `IvPBox` narrows the dimension with `m_dim = (short int)g_dim`, so a large
  `dim` silently becomes small, zero or negative. When it is not positive no
  arrays are allocated at all, while the caller still writes through `m_pts`,
  `m_bds` and `m_wts`.
* `int wtc = (deg*dim)+1` (`FunctionEncoder.cpp:406-409`) can overflow.

The same parser is duplicated in `FunctionEncoderMK.cpp:292-380`.

## Impact

Memory exhaustion and a null dereference in the operator's function viewer from
an unauthenticated MOOS publisher. The short narrowing is what turns a resource
bug into a memory safety bug: 65 bytes of `BHV_IPF` segfault a stock
`uFunctionVis`.

## Fix

* `dim` is bounded by `MAX_IPF_DIMENSIONS` and `deg` by `MAX_IPF_DEGREE`, both
  added to `FunctionEncoder.h` and both far above any real function: IvP domains
  are one to three dimensions and the pieces are linear or quadratic.
* `pcs` is bounded by the length of the payload itself. Every piece has to
  contribute at least a low bound, a high bound and a coefficient, so a string
  of N bytes cannot honestly describe more than N pieces. That needs no
  arbitrary constant and scales with the data actually supplied.
* The digit accumulators stop as soon as the running value exceeds the payload
  length, which also keeps the `int` from overflowing on a long run of digits.
* `IvPBox` treats a dimension or degree that does not survive the narrowing as
  an empty box, and `PDMap` refuses a negative box count. Both are defence in
  depth for callers other than the decoder.

## Files touched

* `ivp/src/lib_ivpbuild/FunctionEncoder.h`: add `MAX_IPF_DIMENSIONS` and `MAX_IPF_DEGREE`
* `ivp/src/lib_ivpbuild/FunctionEncoder.cpp`: range check the declared counts before allocating
* `ivp/src/lib_ivpcore/IvPBox.cpp`: do not let a large dimension survive the narrowing
* `ivp/src/lib_ivpcore/PDMap.cpp`: refuse a negative box count

## Evidence

Before, stock build of the unpatched revision:

```
Two payload shapes from the report, 67 and 65 bytes, against a live
uFunctionVis:

  [*] publishing BHV_IPF case 'wtc-overflow' (67 bytes)
  [*] publishing BHV_IPF case 'counts' (65 bytes)
  Segmentation fault (core dumped)
  uFunctionVis DEAD
```

After, same test against this branch:

```
Same two shapes against this branch:

  [*] publishing BHV_IPF case 'wtc-overflow' (67 bytes)
  [*] publishing BHV_IPF case 'counts' (65 bytes)
  vsz before = 4271984 kB
  vsz after  = 4271992 kB   growth = 0 MB
  uFunctionVis ALIVE
```

## Notes

Two further problems in the same decoder are reported separately: the copy loops
are bounded by the data rather than by the declared length, and
`StringToIvPContext()` leaks its buffer.
