### PR TITLE
alogsplit: create the split directory without a shell

### DIFF
--- a/ivp/src/lib_logutils/SplitHandler.cpp
+++ b/ivp/src/lib_logutils/SplitHandler.cpp
@@ -23,6 +23,10 @@
 
 #include <iostream>
 #include <cstdlib>
+#include <cerrno>
+#include <cstring>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <cstdio>
 #include <cmath>
 #include "MBUtils.h"
@@ -604,11 +608,13 @@ bool SplitHandler::handlePreCheckSplitDir()
   }
 
   // Part 3: Create and Verify the split directory.
-  // Make the base directory
-  string cmd = "mkdir " + basedir;
-  int result = system(cmd.c_str());
-  if(result != 0) 
-    cout << "Possible err in SplitHandler syscmd mkdir" << endl;
+  // Make the base directory.  basedir is derived from the input pathname or
+  // taken from --dir=, so it must be treated as opaque filesystem data: a
+  // shell would interpret anything in it.
+  int result = mkdir(basedir.c_str(), 0755);
+  if(result != 0)
+    cout << "Possible err in SplitHandler mkdir: "
+	 << strerror(errno) << endl;
 
   
   // Ensure that the base directory has indeed been created.

--- a/ivp/src/lib_logutils/SplitHandler.cpp
+++ b/ivp/src/lib_logutils/SplitHandler.cpp
@@ -608,9 +608,7 @@ bool SplitHandler::handlePreCheckSplitDir()
   }
 
   // Part 3: Create and Verify the split directory.
-  // Make the base directory.  basedir is derived from the input pathname or
-  // taken from --dir=, so it must be treated as opaque filesystem data: a
-  // shell would interpret anything in it.
+  // Make the base directory
   int result = mkdir(basedir.c_str(), 0755);
   if(result != 0)
     cout << "Possible err in SplitHandler mkdir: "


### PR DESCRIPTION
# alogsplit: create the split directory without a shell

alogsplit executes shell syntax embedded in an input pathname

## Problem

`SplitHandler::handlePreCheckSplitDir()`
(`ivp/src/lib_logutils/SplitHandler.cpp:580-608`) creates the cache directory
with a shell:

```
string cmd = "mkdir " + basedir;
int result = system(cmd.c_str());
```

`basedir` is the input log's pathname with its extension replaced by
`_alvtmp`, or the raw `--dir=` value. The only checks on the pathname
(`:116-140`) are that it ends in `.alog`, contains no whitespace and is
`fopen()`-able, so shell metacharacters pass straight through, and the
whitespace check is trivially avoided with `$IFS` or brace expansion. The
`--dir=` route has no whitespace check at all.

## Impact

Arbitrary command execution as the analyst who opens the log, which is typically
a workstation with credentials and access to other missions. No MOOS process
needs to be running. Log filenames travel with logs through every normal
distribution channel: tarballs, vehicle upload directories, shared drives,
email.

## Fix

Call `mkdir()` instead of shelling out, and report `strerror(errno)` on failure.
The path is filesystem data and no shell needs to be involved. Two lines
changed plus the headers.

## Files touched

* `ivp/src/lib_logutils/SplitHandler.cpp`: replace `system("mkdir ...")` with `mkdir()`

## Evidence

Before, stock build of the unpatched revision:

```
Log planted as  mission;id>proof.txt;x.alog , then the tool run on it:

  sh: 1: x_alvtmp: not found
  Possible err in SplitHandler syscmd mkdir
  Cache dur [mission;id>proof.txt;x_alvtmp] could not be created.

  proof.txt:
  uid=1001(ai) gid=1001(ai) groups=1001(ai),27(sudo),...
```

After, same test against this branch:

```
Same planted log against this branch:

  no proof.txt

The directory is created with the literal name the filename asked for, so
nothing in it is interpreted.
```
