### PR TITLE
Index the stripped string with its own length in isBraced and friends

### DIFF
--- a/ivp/src/lib_mbutil/MBUtils.cpp
+++ b/ivp/src/lib_mbutil/MBUtils.cpp
@@ -1697,7 +1697,10 @@ bool isQuoted(const string& str)
   if(len < 2)
     return(false);
 
-  if((mod_str[0] == '"') && (mod_str[str.length()-1] == '"'))
+  // index the stripped string with its own length: str is longer whenever
+  // stripBlankEnds() removed anything, and mod_str[str.length()-1] is then a
+  // read past the end of mod_str
+  if((mod_str[0] == '"') && (mod_str[len-1] == '"'))
     return(true);
   return(false);
 }
@@ -1714,7 +1717,8 @@ bool isBraced(const string& str)
   if(len < 2)
     return(false);
 
-  if((mod_str[0] == '{') && (mod_str[str.length()-1] == '}'))
+  // as above: mod_str must be indexed with its own length, not str's
+  if((mod_str[0] == '{') && (mod_str[len-1] == '}'))
     return(true);
   return(false);
 }
@@ -1731,7 +1735,8 @@ bool isChevroned(const string& str)
   if(len < 2)
     return(false);
   
-  if((mod_str[0] == '<') && (mod_str[str.length()-1] == '>'))
+  // as above: mod_str must be indexed with its own length, not str's
+  if((mod_str[0] == '<') && (mod_str[len-1] == '>'))
     return(true);
   return(false);
 }

--- a/ivp/src/lib_mbutil/MBUtils.cpp
+++ b/ivp/src/lib_mbutil/MBUtils.cpp
@@ -1697,9 +1697,6 @@ bool isQuoted(const string& str)
   if(len < 2)
     return(false);
 
-  // index the stripped string with its own length: str is longer whenever
-  // stripBlankEnds() removed anything, and mod_str[str.length()-1] is then a
-  // read past the end of mod_str
   if((mod_str[0] == '"') && (mod_str[len-1] == '"'))
     return(true);
   return(false);
@@ -1717,7 +1714,6 @@ bool isBraced(const string& str)
   if(len < 2)
     return(false);
 
-  // as above: mod_str must be indexed with its own length, not str's
   if((mod_str[0] == '{') && (mod_str[len-1] == '}'))
     return(true);
   return(false);
@@ -1735,7 +1731,6 @@ bool isChevroned(const string& str)
   if(len < 2)
     return(false);
   
-  // as above: mod_str must be indexed with its own length, not str's
   if((mod_str[0] == '<') && (mod_str[len-1] == '>'))
     return(true);
   return(false);


### PR DESCRIPTION
# Index the stripped string with its own length in isBraced and friends

isBraced()/isQuoted()/isChevroned() index the stripped string with the original length

## Problem

`isBraced()`, `isQuoted()` and `isChevroned()`
(`ivp/src/lib_mbutil/MBUtils.cpp:1700, 1717, 1734`) strip the blank ends of
their argument into `mod_str` and then test the last character with

```
mod_str[str.length()-1]
```

That indexes the stripped string with the length of the original. Whenever
`stripBlankEnds()` removed anything, `str` is longer than `mod_str` and the read
is past the end of `mod_str`, by exactly the number of characters stripped.

`isBraced()` sits on the `NODE_REPORT` parsing path:
`string2NodeRecord()` (`ivp/src/lib_contacts/NodeRecordUtils.cpp:119`) calls it
on a value published by any MOOS client.

## Impact

An unauthenticated MOOS publisher causes an out of bounds heap read of
attacker chosen length in `pContactMgrV20`, and in anything else that parses
node reports: `uFldNodeComms`, `pMarineViewer` and the rest of the
`ContactLedger` users. A 100 MB payload segfaults a stock build.

## Fix

Index `mod_str` with its own length in all three functions. `len` is already
computed immediately above for the `len < 2` check, so the fix is to use it.

## Files touched

* `ivp/src/lib_mbutil/MBUtils.cpp`: use the stripped string's own length in `isQuoted()`, `isBraced()` and `isChevroned()`

## Evidence

Before, stock build of the unpatched revision:

```
Sanitised build, 5,000 trailing spaces, delivered over the network:

  ==160422==ERROR: AddressSanitizer: heap-buffer-overflow
  READ of size 1
      #0 in isBraced(std::string const&)           MBUtils.cpp:1717
      #1 in string2NodeRecord(std::string const&)  NodeRecordUtils.cpp:119
      #2 in ContactMgrV20::handleMailNodeReport(std::string, std::string&)

Stock build, escalating payloads against a live pContactMgrV20:

  5,000       trailing spaces -> survived (silent over-read)
  2,000,000   trailing spaces -> survived
  100,000,000 trailing spaces -> Segmentation fault (core dumped)
  >> pContactMgrV20 DEAD
```

After, same test against this branch:

```
Same escalation against this branch:

  5,000       trailing spaces -> survived
  2,000,000   trailing spaces -> survived
  20,000,000  trailing spaces -> survived
  100,000,000 trailing spaces -> survived
  >> pContactMgrV20 ALIVE
```
