### PR TITLE
Bound and validate the mux header in Demuxer::addMuxPacket

### DIFF
--- a/ivp/src/lib_ivpbuild/Demuxer.cpp
+++ b/ivp/src/lib_ivpbuild/Demuxer.cpp
@@ -92,32 +92,52 @@ bool Demuxer::addMuxPacket(const string& str, double time_stamp,
   // is labeled not up-to-date by setting demuxed=false. 
   m_demuxed = false;
 
+  // The header is read from a MOOS variable, so nothing about it can be
+  // assumed: the delimiters may be missing and the numbers may be anything.
+  const int slen = (int)str.length();
+
   // Determine the "ID" of the string
   int cix = 2;
   string str_id = "";
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
     str_id += str[cix];
     cix++;
   }
+  if(cix >= slen)
+    return(false);
 
   // Determine the number of total packets
   cix++;
   int str_total = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
+    if((str[cix] < '0') || (str[cix] > '9'))
+      return(false);
     str_total *= 10;
     str_total += (int)(str[cix]-48);
+    if(str_total > MAX_MUX_PACKETS)
+      return(false);
     cix++;
   }
+  if((cix >= slen) || (str_total < 1))
+    return(false);
 
   // Determine the index of this packet
   cix++;
   int str_ix = 0;
-  while(str[cix] != ',') {
+  while((cix < slen) && (str[cix] != ',')) {
+    if((str[cix] < '0') || (str[cix] > '9'))
+      return(false);
     str_ix *= 10;
     str_ix += (int)(str[cix]-48);
+    if(str_ix > str_total)
+      return(false);
     cix++;
   }
+  if(cix >= slen)
+    return(false);
   str_ix--;
+  if(str_ix < 0)
+    return(false);
   cix++;
   
   string str_body = str.c_str() + cix;

--- a/ivp/src/lib_ivpbuild/Demuxer.h
+++ b/ivp/src/lib_ivpbuild/Demuxer.h
@@ -31,6 +31,12 @@
 #include "DemuxUnit.h"
 #include "DemuxedResult.h"
 
+// The largest number of packets one multiplexed string may declare.  The
+// figure arrives in the payload and each packet reserves a std::string in the
+// DemuxUnit, so it needs a ceiling.  A real IvP function is a handful of
+// packets; this is generous.
+#define MAX_MUX_PACKETS 1024
+
 class Demuxer {
 public:
   Demuxer() {m_demuxed=true;}


### PR DESCRIPTION
# Bound and validate the mux header in Demuxer::addMuxPacket

BHV_IPF demultiplexer trusts attacker-declared packet counts

## Problem

`Demuxer::addMuxPacket()` (`ivp/src/lib_ivpbuild/Demuxer.cpp:88-144`) parses the
mux header of a `BHV_IPF` payload with three loops of the form

```
while(str[cix] != ',') { total *= 10; total += str[cix]-48; cix++; }
```

There is no end of string check, so a header without delimiters walks off the
end of the `std::string`. There is no digit check, so any byte is accumulated as
a digit. And there is no maximum, so the declared fragment count is whatever the
publisher says.

`DemuxUnit`'s constructor (`ivp/src/lib_ivpbuild/DemuxUnit.cpp:34-46`) then does

```
for(i=0; i<g_total_packets; i++) { m_data.push_back(""); m_flag.push_back(false); }
```

`uFunctionVis` feeds `BHV_IPF` straight into this
(`ivp/src/uFunctionVis/FV_MOOSApp.cpp:63-66`) and never calls
`removeStaleUnits()`.

## Impact

A 21 byte message declaring 900,000,000 fragments makes the consumer reserve
900,000,000 `std::string`s and 900,000,000 bools. Measured against a live
`uFunctionVis`: RSS from 81 MB to 28.3 GB, unauthenticated. This is the largest
amplification factor in the set.

## Fix

In `addMuxPacket()`:

* every scan loop stops at the end of the string, and a header that runs out
  before its delimiter is rejected;
* the count and index fields accept digits only;
* the declared fragment count is capped by `MAX_MUX_PACKETS` (1024, added to
  `Demuxer.h`) and must be at least 1;
* the packet index must lie inside the declared count.

A rejected packet returns false, which is already what `addMuxPacket()` returns
when a unit refuses a string, so no new error path is introduced. A real IvP
function is a handful of packets, so the ceiling is generous.

## Files touched

* `ivp/src/lib_ivpbuild/Demuxer.h`: add `MAX_MUX_PACKETS`
* `ivp/src/lib_ivpbuild/Demuxer.cpp`: bounded, digit checked, range checked header parsing

## Evidence

Before, stock build of the unpatched revision:

```
Three payload shapes against a live uFunctionVis: a declared count of
900,000,000 in 21 bytes, a header with no delimiters at all, and 4000 distinct
unit ids.

  rss before = 81220 kB
  rss after  = 28348436 kB      growth = 27604 MB
```

After, same test against this branch:

```
Same three shapes against this branch:

  rss before = 81816 kB
  rss after  = 82968 kB         growth = 1 MB
```
