### PR TITLE
Free the context buffer in StringToIvPContext

### DIFF
--- a/ivp/src/lib_ivpbuild/FunctionEncoder.cpp
+++ b/ivp/src/lib_ivpbuild/FunctionEncoder.cpp
@@ -521,6 +521,8 @@ string StringToIvPContext(const string& str)
   cix++;
 
   string rstring = cstr_buff;
+  delete [] cstr_buff;
+
   return(rstring);
 }
 


### PR DESCRIPTION
# Free the context buffer in StringToIvPContext

StringToIvPContext leaks an attacker-sized allocation per payload

## Problem

`StringToIvPContext()` (`ivp/src/lib_ivpbuild/FunctionEncoder.cpp:499-524`)
allocates the context buffer with

```
char *cstr_buff = new char[cstr_len+10];
```

copies the field into it, builds a `std::string` from it and returns, never
calling `delete[]`. `cstr_len` is a number in the `BHV_IPF` payload, so whoever
publishes the payload chooses how much is leaked per call.
`StringToIvPFunction()`, immediately above in the same file, does free its copy.

## Impact

Monotonic, unbounded memory exhaustion of the consuming process at a rate the
publisher sets, with no authentication. A 65 byte message can declare a 100 MB
context string. `uFunctionVis` calls this once per demuxed payload
(`ivp/src/uFunctionVis/FV_MOOSApp.cpp:125`), and `IPF_Bundle` and
`IPF_BundleSeries` call it again per bundle and per `addIPF`, so 40 messages
totalling 2.6 KB on the wire cost the consumer 12 GB of address space.

## Fix

`delete[]` the buffer after the `std::string` has been constructed from it. One
line, and the same shape as the sibling function already uses.

## Files touched

* `ivp/src/lib_ivpbuild/FunctionEncoder.cpp`: free the context buffer in `StringToIvPContext()`

## Evidence

Before, stock build of the unpatched revision:

```
40 messages of 65 bytes each against a live uFunctionVis. VmSize is the
measure that matters here, because the allocation is never written to and so
does not appear in VmRSS:

  vsz before = 4271980 kB
  vsz after  = 16560468 kB     growth = 12000 MB

LeakSanitizer on the same run:
  Direct leak of 104857610 byte(s) in 1 object(s) allocated from:
    #1 StringToIvPContext(...) FunctionEncoder.cpp:513
```

After, same test against this branch:

```
Same 40 messages against this branch:

  vsz before = 4271984 kB
  vsz after  = 4271992 kB      growth = 0 MB
```

## Notes

The same function has two other defects reported separately: the copy loop is
bounded by the data rather than by the declared length, and the counts in the
payload are unchecked. This patch is only the leak, so it can land on its own.
