### PR TITLE
uFldNodeComms: bound how many nodes may be tracked

### DIFF
--- a/ivp/src/uFldNodeComms/FldNodeComms.cpp
+++ b/ivp/src/uFldNodeComms/FldNodeComms.cpp
@@ -38,6 +38,11 @@ using namespace std;
 
 FldNodeComms::FldNodeComms()
 {
+  // Ceiling on how many distinct nodes we will track.  The distribution
+  // below is all-pairs, so this bounds the work per pass as well as the
+  // memory.
+  m_max_node_count   = 100;
+
   // The default range within which reports are sent between nodes
   m_comms_range      = 100;
 
@@ -257,6 +262,18 @@ bool FldNodeComms::OnStartUp()
       handled = setNonNegDoubleOnString(m_min_msg_interval, value);
     else if(param == "min_rpt_interval") 
       handled = setNonNegDoubleOnString(m_min_rpt_interval, value);
+    else if(param == "max_node_count") {
+      // Every distinct NAME in a NODE_REPORT becomes a ledger entry, and
+      // distributeNodeReportInfo() walks the whole ledger for each new
+      // record, so the work per pass grows with the square of the number of
+      // asserted nodes.  Bound the ledger.
+      if(isNumber(value) && (atoi(value.c_str()) > 0)) {
+	m_max_node_count = (unsigned int)(atoi(value.c_str()));
+	handled = true;
+      }
+      else
+	handled = false;
+    }
     else if(param == "max_msg_length")
       handled = setUIntOnString(m_max_msg_length, value);
     else if(param == "stealth") 
@@ -314,8 +331,22 @@ void FldNodeComms::registerVariables()
 
 bool FldNodeComms::handleMailNodeReport(const string& str, string& whynot)
 {
+  // A report for a name we have not seen before adds a node to the ledger,
+  // and distributeNodeReportInfo() then walks the whole ledger for it.  The
+  // name is chosen by whoever published the report, so refuse a new one once
+  // the ceiling is reached.  Reports for nodes we already track still go
+  // through, so an established field is unaffected.
+  string rpt_vname = tokStringParse(str, "NAME", ',', '=');
+  if((rpt_vname != "") && !m_ledger.hasVName(rpt_vname) &&
+     (m_ledger.getVNames().size() >= m_max_node_count)) {
+    whynot = "max_node_count (" + uintToString(m_max_node_count) + ") reached";
+    return(false);
+  }
+
   string vname = m_ledger.processNodeReport(str, whynot);
   if(whynot != "")
+    return(false);
+  if(vname == "")
     return(false);
 
   m_map_newrecord[vname] = true;

--- a/ivp/src/uFldNodeComms/FldNodeComms.h
+++ b/ivp/src/uFldNodeComms/FldNodeComms.h
@@ -119,6 +119,10 @@ protected:
  
  protected: // State variables
   ContactLedger m_ledger;
+
+  // Ceiling on how many distinct nodes may occupy the ledger.  The node
+  // report distribution is all-pairs, so this bounds work as well as memory.
+  unsigned int  m_max_node_count;
   
   // Holds last time posted local share, if enabled, for each vname
   std::map<std::string, double>  m_map_lshare_tstamp;     


### PR DESCRIPTION
# uFldNodeComms: bound how many nodes may be tracked

Unique NODE_REPORT identities trigger quadratic uFldNodeComms work

## Problem

`handleMailNodeReport()` (`ivp/src/uFldNodeComms/FldNodeComms.cpp:315-321`) hands
every `NODE_REPORT` to the ledger, and every new `NAME` becomes a ledger entry
flagged as a new record. `distributeNodeReportInfo()` (`:518-526`) then walks the
whole ledger for each new record, and that all-pairs distribution (`:840-900`)
runs before any staleness cleanup. The names are chosen by whoever publishes the
reports, so the work per pass grows with the square of the number of asserted
nodes.

## Impact

A few hundred kilobytes of asserted node identities multiply the broker's steady
state CPU by orders of magnitude and grow its memory without bound. This is the
process every vehicle depends on for vehicle to vehicle messaging. Measured:
4000 unique names, about 440 kB of reports, take uFldNodeComms from no measurable
CPU to 9314 ticks and from 5.4 MB to 551 MB of RSS.

## Fix

Add `max_node_count`, default 100. A report naming a node that is not already
tracked is refused once the ceiling is reached, with the reason returned in
`whynot`, which is the mechanism this handler already uses for a report it will
not accept. Reports for nodes already tracked still go through, so an established
field is unaffected. A field with more than 100 vehicles raises the number in the
mission file.

## Files touched

* `ivp/src/uFldNodeComms/FldNodeComms.h`: add `m_max_node_count`
* `ivp/src/uFldNodeComms/FldNodeComms.cpp`: read `max_node_count`, refuse a report for an untracked node beyond it

## Evidence

Before, stock build of the unpatched revision:

```
4000 unique NODE_REPORT names against a live uFldNodeComms:

  cpu0 = (0 0)          rss0 = 5444 kB
  cpu1 = (6931 2383)    rss1 = 550916 kB      # 9314 ticks
```

After, same test against this branch:

```
Same 4000 names against this branch:

  cpu0 = (0 0)          rss0 = 5396 kB
  cpu1 = (28 18)        rss1 = 6604 kB        # 46 ticks
```

## Notes

The exploit also times a genuine node to node message before and after the
flood. In this harness that measurement was the same on both versions (15.2s
before the flood, not delivered within the 25s window after it), because the
message interval settings already put it at the edge of that window; the CPU and
RSS figures are the ones that separate the two builds. The all-pairs shape of
`distributeNodeReportInfo()` is unchanged by this patch: it is now bounded, not
eliminated.
