### PR TITLE
pRealm: bound what a REALMCAST_REQ may ask for

### DIFF
--- a/ivp/src/pRealm/PipeWay.cpp
+++ b/ivp/src/pRealm/PipeWay.cpp
@@ -115,6 +115,16 @@ bool PipeWay::valid() const
   if(m_client == "")
     return(false);
 
+  // The duration decides how long this pipeway keeps being serialised and
+  // published on every interval, and it comes from the request.
+  if((m_duration < 0) || (m_duration > MAX_PIPEWAY_DURATION))
+    return(false);
+
+  // The variable list is a ':' separated list in the request with no length
+  // of its own, and every variable is rendered every interval.
+  if(m_vars.size() > MAX_PIPEWAY_VARS)
+    return(false);
+
   return(true);
 }
 

--- a/ivp/src/pRealm/PipeWay.h
+++ b/ivp/src/pRealm/PipeWay.h
@@ -28,6 +28,12 @@
 #include <map>
 #include <set>
 
+// Limits on what one REALMCAST_REQ may ask for.  Everything in the request is
+// chosen by whoever published it, and every live pipeway is serialised and
+// published on every interval, so none of it may be unbounded.
+#define MAX_PIPEWAY_DURATION 3600    // seconds
+#define MAX_PIPEWAY_VARS     64      // variables in one request
+
 class PipeWay
 {
  public:

--- a/ivp/src/pRealm/Realm.cpp
+++ b/ivp/src/pRealm/Realm.cpp
@@ -35,6 +35,7 @@ using namespace std;
 
 Realm::Realm()
 {
+  m_max_pipeways = 64;
   // Init Config Variables
   m_msg_max_hist = 10;
 
@@ -289,6 +290,16 @@ void Realm::handleMailRealmCastReq(string sval)
   string client = pipeway.getClient();
 
   if(m_map_pipeways.count(client) == 0) {
+    // The client name is simply a string in the request, so it is a map key
+    // an unauthenticated publisher chooses.  Each entry is serialised and
+    // published on every interval, so refuse a new one once the ceiling is
+    // reached; existing clients keep being refreshed.
+    if(m_map_pipeways.size() >= m_max_pipeways) {
+      reportRunWarning("Refused RealmCastReq from " + client +
+		       ": max_pipeways (" + uintToString(m_max_pipeways) +
+		       ") reached");
+      return;
+    }
     m_map_pipeways[client] = pipeway;
   }
   else {  

--- a/ivp/src/pRealm/Realm.h
+++ b/ivp/src/pRealm/Realm.h
@@ -116,6 +116,10 @@ class Realm : public AppCastingMOOSApp
   // Key is the client, e.g., pmv, umview 
   std::map<std::string, PipeWay> m_map_pipeways;
 
+  // Ceiling on how many distinct clients may hold a pipeway.  Each one is
+  // serialised and published on every interval.
+  unsigned int m_max_pipeways;
+
   std::map<std::string, double> m_map_var_last_wcast;
 
   std::string m_last_post_summary_info;


### PR DESCRIPTION
# pRealm: bound what a REALMCAST_REQ may ask for

REALMCAST_REQ permits persistent unbounded output amplification

## Problem

Everything in a `REALMCAST_REQ` is chosen by whoever published it, and
`PipeWay::valid()` (`ivp/src/pRealm/PipeWay.cpp:109-119`) only tests that the
client is non-empty, the duration is non-zero, and there is either a channel or
one variable:

* the duration has no upper bound, so `duration=1000000000` keeps a pipeway
  alive for about 31 years;
* the variable list is a `:` separated list with no length limit
  (`string2PipeWay()`, `:180-215`), and every variable is rendered on every
  interval;
* the client name is a map key (`Realm::handleMailRealmCastReq()`, `:281-303`),
  so one publisher can create as many distinct pipeways as it likes.

`buildRealmCast()` and `buildWatchCast()` (`:340-447`) serialise every live
pipeway and publish it on every interval.

## Impact

Unauthenticated CPU and memory amplification against a process that shares the
vehicle computer with the helm, for a duration the attacker chooses. Measured:
500 requests with a 31 year duration take pRealm from no measurable CPU to 1043
ticks and from 4.7 MB to 15 MB, and the pipeways are still there minutes later.

## Fix

* `MAX_PIPEWAY_DURATION` (3600 seconds) and `MAX_PIPEWAY_VARS` (64), both in
  `PipeWay.h`, are enforced by `valid()`, so an out of range request is rejected
  on the path that already reports `Bad RealmCastReq`.
* `m_max_pipeways` (64) bounds how many distinct clients may hold a pipeway.
  Clients already present keep being refreshed; only a new one is refused, with a
  run warning naming it.

## Files touched

* `ivp/src/pRealm/PipeWay.h`: add `MAX_PIPEWAY_DURATION` and `MAX_PIPEWAY_VARS`
* `ivp/src/pRealm/PipeWay.cpp`: enforce both in `valid()`
* `ivp/src/pRealm/Realm.h`: add `m_max_pipeways`
* `ivp/src/pRealm/Realm.cpp`: refuse a new client beyond the ceiling

## Evidence

Before, stock build of the unpatched revision:

```
500 REALMCAST_REQ pipes, each with duration=1000000000:

  cpu0 = (0 0)        rss0 = 4700 kB
  cpu1 = (1034 9)     rss1 = 15032 kB      # 1043 ticks
```

After, same test against this branch:

```
Same 500 requests against this branch:

  cpu0 = (0 0)        rss0 = 4736 kB
  cpu1 = (5 4)        rss1 = 5120 kB       # 9 ticks
```

## Notes

An hour is a generous ceiling for a scope subscription, and a client that wants
longer simply renews, which is what the refresh path already does on every
request. The variable and client ceilings are constants in the header rather than
mission file parameters, because pRealm's own configuration block is not where an
operator would expect to tune a defence against a hostile publisher.
