### PR TITLE
uFldShoreBroker: bound how many nodes may enrol

### DIFF
--- a/ivp/src/uFldShoreBroker/ShoreBroker.cpp
+++ b/ivp/src/uFldShoreBroker/ShoreBroker.cpp
@@ -37,6 +37,7 @@ using namespace std;
 
 ShoreBroker::ShoreBroker()
 {
+  m_max_node_count   = 100;
   // Initialize config variables
   m_warning_on_stale = false;
 
@@ -161,6 +162,12 @@ bool ShoreBroker::OnStartUp()
       handleConfigQBridge(value);
     else if(param == "keyword") 
       m_keyword = value;
+    else if(param == "max_node_count") {
+      if(isNumber(value) && (atoi(value.c_str()) > 0))
+	m_max_node_count = (unsigned int)(atoi(value.c_str()));
+      else
+	handled = false;
+    }
     else if(param == "auto_bridge_realmcast") 
       handled = setBooleanOnString(auto_bridge_realmcast, value);
     else if(param == "auto_bridge_appcast") 
@@ -443,6 +450,15 @@ void ShoreBroker::handleMailNodePing(const string& info)
       m_node_host_records[j].setStatus(status);
       return;
     }
+  }
+
+  // Refuse to enrol a new community once the ceiling is reached.  Existing
+  // nodes above keep being updated; only growth is stopped.
+  if(m_node_host_records.size() >= m_max_node_count) {
+    reportRunWarning("Refused NODE_BROKER_PING from " +
+		     hrecord.getCommunity() + ": max_node_count (" +
+		     uintToString(m_max_node_count) + ") reached");
+    return;
   }
 
   string config = "src=NODE_BROKER_ACK_$V, alias=NODE_BROKER_ACK";

--- a/ivp/src/uFldShoreBroker/ShoreBroker.h
+++ b/ivp/src/uFldShoreBroker/ShoreBroker.h
@@ -73,6 +73,12 @@ class ShoreBroker : public AppCastingMOOSApp
 
   std::string m_keyword;
 
+  // Ceiling on how many distinct communities may be enrolled.  Each one adds
+  // an entry to six parallel vectors which are then walked every pass, and
+  // nothing ever removes an entry, so an unauthenticated sender can grow the
+  // work this app does per iteration without bound.
+  unsigned int m_max_node_count;
+
   bool m_warning_on_stale;
 
   std::set<std::string> m_set_qbridge_vars;


### PR DESCRIPTION
# uFldShoreBroker: bound how many nodes may enrol

ShoreBroker retains an unbounded set of spoofed communities

## Problem

`handleMailNodePing()` (`ivp/src/uFldShoreBroker/ShoreBroker.cpp:436-462`)
enrols any community it has not seen before by appending to six parallel
vectors. Nothing ever removes an entry: `checkForStaleNodes()` (`:219-338`) only
sets `m_node_is_stale[i] = true`, while `sendAcks()`, `postNodeCount()` and
`makeBridgeRequestAll()` (`:502-528`) keep walking the full vectors and emit one
`PSHARE_CMD` per bridge variable per node on every pass.

## Impact

A few hundred kilobytes of asserted communities grow the broker without bound and
multiply its periodic work permanently, until legitimate nodes stop being
acknowledged and stop getting their bridges, so real vehicles fall out of the
field network. Measured: 3000 pings totalling 354 kB enrol 3000 nodes and take
the broker from no measurable CPU to 197 ticks over the same window.

## Fix

Add `max_node_count`, default 100, and refuse to enrol a new community once it is
reached. Nodes already enrolled keep being updated, so an established field is
unaffected; only growth is stopped, and the refusal is reported as a run warning
naming the community. A field with more than 100 vehicles raises the number in
the mission file.

## Files touched

* `ivp/src/uFldShoreBroker/ShoreBroker.h`: add `m_max_node_count`
* `ivp/src/uFldShoreBroker/ShoreBroker.cpp`: read `max_node_count`, refuse enrolment beyond it

## Evidence

Before, stock build of the unpatched revision:

```
3000 pings, each claiming a community the shore has never seen:

  sent 3000 pings
  UFSB_NODE_COUNT = 3000.0
  cpu ticks (utime stime): 0 0 -> 172 25
  rss = 8372 kB
```

After, same test against this branch:

```
Same 3000 pings against this branch:

  sent 3000 pings
  UFSB_NODE_COUNT = 100.0
  cpu ticks (utime stime): 0 0 -> 8 6
  rss = 5164 kB
```

## Notes

A cap bounds the damage; it does not decide who deserves a slot, so an attacker
that gets in first can still fill the table. The complementary fixes are to make
the keyword mismatch a refusal, and to actually remove stale entries rather than
only flagging them. The first of those is reported separately; the second is a
larger change to six parallel vectors and is worth doing on its own.
