### PR TITLE
setVarDataPairOnString: re-check for an empty string after biting it

### DIFF
--- a/ivp/src/lib_mbutil/VarDataPairUtils.cpp
+++ b/ivp/src/lib_mbutil/VarDataPairUtils.cpp
@@ -57,11 +57,21 @@ bool setVarDataPairOnString(VarDataPair& pair, string str)
   if((str.at(0) == '@') || (str.at(0) == '<') || (str.at(0) == '>'))
     post_tag = tolower(biteStringX(str, ' '));
 
+  // biteStringX() on a string with no separator consumes the whole thing, so
+  // the check at the top of this function no longer tells us anything: str
+  // may be empty from here on and str.at(0) would throw std::out_of_range.
+  if(str == "")
+    return(false);
+
   // Part 3: Check for Destination tag
   string dest_tag;
   if(str.at(0) == '#') {
     biteStringX(str, '#');
     dest_tag = tolower(biteStringX(str, ' '));
+
+    // as above
+    if(str == "")
+      return(false);
   }
   
   // Part 4: Check for conditional

--- a/ivp/src/lib_mbutil/VarDataPairUtils.cpp
+++ b/ivp/src/lib_mbutil/VarDataPairUtils.cpp
@@ -57,9 +57,7 @@ bool setVarDataPairOnString(VarDataPair& pair, string str)
   if((str.at(0) == '@') || (str.at(0) == '<') || (str.at(0) == '>'))
     post_tag = tolower(biteStringX(str, ' '));
 
-  // biteStringX() on a string with no separator consumes the whole thing, so
-  // the check at the top of this function no longer tells us anything: str
-  // may be empty from here on and str.at(0) would throw std::out_of_range.
+  // The string had no separator and was bitten
   if(str == "")
     return(false);
 


### PR DESCRIPTION
# setVarDataPairOnString: re-check for an empty string after biting it

Uncaught std::out_of_range in setVarDataPairOnString()

## Problem

`setVarDataPairOnString()` (`ivp/src/lib_mbutil/VarDataPairUtils.cpp:46-62`)
sanity checks its argument and then destroys the property it just established:

```
str = stripBlankEnds(str);
if(str == "") return(false);          // str is non-empty here

string post_tag;
if((str.at(0)=='@') || (str.at(0)=='<') || (str.at(0)=='>'))
  post_tag = tolower(biteStringX(str, ' '));   // with no space, EMPTIES str

string dest_tag;
if(str.at(0) == '#') { ... }          // throws on an empty str
```

`biteStringX()` on a string with no separator consumes the whole string, so a
configuration line of `@cpa` with nothing after it leaves `str` empty and the
next `str.at(0)` throws `std::out_of_range`. Nothing on the path catches it.
`VCheckSet.cpp:76` reaches this from VCheck configuration.

## Impact

A malformed configuration line aborts the tool that reads it: `alogeval`, and
any mission file consumer of VCheck configuration. Local and offline only, which
is why this is the mildest of the set, but a configuration parser should not
abort the process on input it simply cannot parse.

## Fix

Re-check for an empty string after each `biteStringX()` that can consume it, and
return false, which is what the function already does for input it cannot parse.

## Files touched

* `ivp/src/lib_mbutil/VarDataPairUtils.cpp`: re-check for an empty string after the post tag and destination tag bites

## Evidence

Before, stock build of the unpatched revision:

```
A harness built against the real library, driving the parser with four short
lines and one well formed one:

  "@"          -> exit 134  what():  basic_string::at: __n (which is 0) >= this->size() (which is 0)
  "@cpa"       -> exit 134  what():  basic_string::at: __n (which is 0) >= this->size() (which is 0)
  "<x"         -> exit 134  what():  basic_string::at: __n (which is 0) >= this->size() (which is 0)
  ">y"         -> exit 134  what():  basic_string::at: __n (which is 0) >= this->size() (which is 0)
  "NORMAL=ok"  -> RETURNED ok=1 (no crash)
```

After, same test against this branch:

```
Same five lines against this branch:

  "@"          -> RETURNED ok=0 (no crash)
  "@cpa"       -> RETURNED ok=0 (no crash)
  "<x"         -> RETURNED ok=0 (no crash)
  ">y"         -> RETURNED ok=0 (no crash)
  "NORMAL=ok"  -> RETURNED ok=1 (no crash)
```
