### PR TITLE
Bound the .ipf file parser

### DIFF
--- a/ivp/src/lib_ivpbuild/IO_Utilities.cpp
+++ b/ivp/src/lib_ivpbuild/IO_Utilities.cpp
@@ -140,10 +140,12 @@ vector<IvPFunction*> readFunctions(const string& str)
     if(c == 'F') {
       int buff_ix = 0;
       while(c != '\n') {
-	result = fscanf(f, "%c", &c);
+	// fscanf() leaves c unchanged at end of file, so without this the
+	// loop never terminates on a truncated file
+	if(fscanf(f, "%c", &c) != 1)
+	  break;
 	if(buff_ix < MAX_LINE_LENGTH-1)
-	  buff[buff_ix] = c;
-	buff_ix++;
+	  buff[buff_ix++] = c;
       }
       buff[buff_ix] = '\0';
     }
@@ -180,10 +182,11 @@ vector<IvPFunction*> readFunctions(const string& str)
     if(c == 'A') {
       int buff_ix = 0;
       while(c != '\n') {
-	result = fscanf(f, "%c", &c);
-	if(buff_ix < MAX_LINE_LENGTH)
-	  buff[buff_ix] = c;
-	buff_ix++;
+	// as above: stop at end of file, and leave room for the terminator
+	if(fscanf(f, "%c", &c) != 1)
+	  break;
+	if(buff_ix < MAX_LINE_LENGTH-1)
+	  buff[buff_ix++] = c;
       }
       buff[buff_ix] = '\0';
       contextStr = buff;
@@ -196,6 +199,14 @@ vector<IvPFunction*> readFunctions(const string& str)
     IvPDomain domain = stringToDomain(domain_str);
     
     PDMap *pdmap = readPDMap(f, dim, boxCount, domain, degree);
+
+    // readPDMap() returns null on a file it cannot make sense of, and
+    // IvPFunction's constructor asserts on a null pdmap
+    if(!pdmap) {
+      fclose(f);
+      return(rvector);
+    }
+
     IvPFunction *new_of = new IvPFunction(pdmap);
     new_of->setContextStr(contextStr);
     new_of->setPWT(pwt);
@@ -229,11 +240,22 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
 
   PDMap *pdmap = new PDMap(boxCount, domain, deg);
 
+  // Bounds read from the file are used to index the grid built below, so they
+  // have to lie inside the domain.  Anything else is not a short read, it is
+  // an unusable function.
+  int dim_pts[dim];
+  for(d=0; d<dim; d++)
+    dim_pts[d] = (d < (int)domain.size()) ? domain.getVarPoints(d) : 0;
+
   IvPBox gelbox(dim);
   if(c == 'G') {
     for(d=0; d<dim; d++) {
       result = fscanf(f, "%d ", &low);
       result = fscanf(f, "%d ", &high);
+      if((low < 0) || (high < low) || (high >= dim_pts[d])) {
+	delete pdmap;
+	return(0);
+      }
       gelbox.setPTS(d, low, high);
     }
     pdmap->setGelBox(gelbox);
@@ -241,11 +263,20 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
 
   for(int i=0; i<boxCount; i++) {
     result = fscanf(f, "%c ", &c);
-    result = fscanf(f, "%d ", &wtc);
+    if(fscanf(f, "%d ", &wtc) != 1)
+      break;
     IvPBox *newbox = new IvPBox(dim, deg);
+
+    // wtc comes from the file but the box was sized from dim and deg, so a
+    // larger figure would write past the end of newbox's weight array
+    if((wtc < 0) || (wtc > newbox->getWtc()))
+      wtc = newbox->getWtc();
+
     for(d=0; d<dim; d++) {
-      result = fscanf(f, "%s ", lowBuff);
-      result = fscanf(f, "%s ", highBuff);
+      // width limits must match the buffers below, or a long token is a
+      // stack overflow
+      result = fscanf(f, "%79s ", lowBuff);
+      result = fscanf(f, "%79s ", highBuff);
       if(lowBuff[0]=='X') {         // Check for bound Xclusive
 	newbox->bd(d, 0) = 0;       // bound. If X is first char
 	lowBuff[0] = '+';           // set bound to exclusive (0)
@@ -256,10 +287,15 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
       }
       low = atoi(lowBuff);
       high = atoi(highBuff);
+      if((low < 0) || (high < low) || (high >= dim_pts[d])) {
+	delete newbox;
+	delete pdmap;
+	return(0);
+      }
       newbox->setPTS(d, low, high);
     }
     for(d=0; d<wtc; d++) {
-      result = fscanf(f, "%s ", buff);
+      result = fscanf(f, "%499s ", buff);
       newbox->wt(d) = atof(buff);
     }
     pdmap->bx(i) = newbox;

--- a/ivp/src/lib_ivpbuild/IO_Utilities.cpp
+++ b/ivp/src/lib_ivpbuild/IO_Utilities.cpp
@@ -222,13 +222,15 @@ vector<IvPFunction*> readFunctions(const string& str)
 PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
 {
   if(f==0) return(0);
+
+  // The header dimension is used to size boxes while the domain sizes the
+  // PDMap grid. They must agree before either is constructed.
+  if((dim != (int)domain.size()) || (boxCount < 0) || (deg < 0))
+    return(0);
   
-  // Pretend we care about the fscanf result to avoid compiler warning
-  int result = 0;
   char c;
-  result = fscanf(f, "%c", &c);
-  if(result == 0)
-    cout << "matching failure" << endl;
+  if(fscanf(f, "%c", &c) != 1)
+    return(0);
   if(c == 'B') 
     ungetc(c, f);
   else
@@ -240,43 +242,53 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
 
   PDMap *pdmap = new PDMap(boxCount, domain, deg);
 
-  // Bounds read from the file are used to index the grid built below, so they
-  // have to lie inside the domain.  Anything else is not a short read, it is
-  // an unusable function.
-  int dim_pts[dim];
-  for(d=0; d<dim; d++)
-    dim_pts[d] = (d < (int)domain.size()) ? domain.getVarPoints(d) : 0;
-
   IvPBox gelbox(dim);
   if(c == 'G') {
     for(d=0; d<dim; d++) {
-      result = fscanf(f, "%d ", &low);
-      result = fscanf(f, "%d ", &high);
-      if((low < 0) || (high < low) || (high >= dim_pts[d])) {
+      if((fscanf(f, "%d ", &low) != 1) ||
+	 (fscanf(f, "%d ", &high) != 1)) {
+	delete pdmap;
+	return(0);
+      }
+      int dim_pts = domain.getVarPoints(d);
+      if((low < 0) || (high < low) || (high >= dim_pts)) {
 	delete pdmap;
 	return(0);
       }
       gelbox.setPTS(d, low, high);
     }
-    pdmap->setGelBox(gelbox);
+    if(!pdmap->setGelBox(gelbox)) {
+      delete pdmap;
+      return(0);
+    }
   }
 
   for(int i=0; i<boxCount; i++) {
-    result = fscanf(f, "%c ", &c);
-    if(fscanf(f, "%d ", &wtc) != 1)
-      break;
+    if((fscanf(f, "%c ", &c) != 1) || (c != 'B') ||
+       (fscanf(f, "%d ", &wtc) != 1)) {
+      delete pdmap;
+      return(0);
+    }
     IvPBox *newbox = new IvPBox(dim, deg);
 
-    // wtc comes from the file but the box was sized from dim and deg, so a
-    // larger figure would write past the end of newbox's weight array
-    if((wtc < 0) || (wtc > newbox->getWtc()))
-      wtc = newbox->getWtc();
+    // The serialized weight count must match the storage allocated from the
+    // header. Accepting a mismatch would either overrun the array or leave a
+    // partially initialized box in the map.
+    if(wtc != newbox->getWtc()) {
+      delete newbox;
+      delete pdmap;
+      return(0);
+    }
 
     for(d=0; d<dim; d++) {
-      // width limits must match the buffers below, or a long token is a
-      // stack overflow
-      result = fscanf(f, "%79s ", lowBuff);
-      result = fscanf(f, "%79s ", highBuff);
+      // Field widths match the buffers, and failed reads are rejected before
+      // their contents are inspected.
+      if((fscanf(f, "%79s ", lowBuff) != 1) ||
+	 (fscanf(f, "%79s ", highBuff) != 1)) {
+	delete newbox;
+	delete pdmap;
+	return(0);
+      }
       if(lowBuff[0]=='X') {         // Check for bound Xclusive
 	newbox->bd(d, 0) = 0;       // bound. If X is first char
 	lowBuff[0] = '+';           // set bound to exclusive (0)
@@ -287,7 +299,8 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
       }
       low = atoi(lowBuff);
       high = atoi(highBuff);
-      if((low < 0) || (high < low) || (high >= dim_pts[d])) {
+      int dim_pts = domain.getVarPoints(d);
+      if((low < 0) || (high < low) || (high >= dim_pts)) {
 	delete newbox;
 	delete pdmap;
 	return(0);
@@ -295,7 +308,11 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
       newbox->setPTS(d, low, high);
     }
     for(d=0; d<wtc; d++) {
-      result = fscanf(f, "%499s ", buff);
+      if(fscanf(f, "%499s ", buff) != 1) {
+	delete newbox;
+	delete pdmap;
+	return(0);
+      }
       newbox->wt(d) = atof(buff);
     }
     pdmap->bx(i) = newbox;
@@ -384,9 +401,6 @@ void printZAIC_PEAK(ZAIC_PEAK zaic)
     cout << "  Maxutil: "   << maxutil << endl;
   }
 }
-
-
-
 
 
 

--- a/ivp/src/lib_ivpbuild/IO_Utilities.cpp
+++ b/ivp/src/lib_ivpbuild/IO_Utilities.cpp
@@ -222,38 +222,38 @@ vector<IvPFunction*> readFunctions(const string& str)
 PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
 {
   if(f==0) return(0);
-
+  
   // The header dimension is used to size boxes while the domain sizes the
   // PDMap grid. They must agree before either is constructed.
   if((dim != (int)domain.size()) || (boxCount < 0) || (deg < 0))
-    return(0);
+  return(0);
   
   char c;
-  if(fscanf(f, "%c", &c) != 1)
-    return(0);
-  if(c == 'B') 
+  if(fscanf(f, "%c", &c) != 1) return(0);
+  
+  if(c == 'B') {
     ungetc(c, f);
-  else
-    if(c != 'G')
-      return(0);
-
+  } else if(c != 'G') {
+    return(0);
+  }
+  
   int     d, low, high, wtc;
   char    buff[500], lowBuff[80], highBuff[80];
-
+  
   PDMap *pdmap = new PDMap(boxCount, domain, deg);
-
+  
   IvPBox gelbox(dim);
   if(c == 'G') {
     for(d=0; d<dim; d++) {
       if((fscanf(f, "%d ", &low) != 1) ||
-	 (fscanf(f, "%d ", &high) != 1)) {
-	delete pdmap;
-	return(0);
+      (fscanf(f, "%d ", &high) != 1)) {
+        delete pdmap;
+        return(0);
       }
       int dim_pts = domain.getVarPoints(d);
       if((low < 0) || (high < low) || (high >= dim_pts)) {
-	delete pdmap;
-	return(0);
+        delete pdmap;
+        return(0);
       }
       gelbox.setPTS(d, low, high);
     }
@@ -262,15 +262,15 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
       return(0);
     }
   }
-
+  
   for(int i=0; i<boxCount; i++) {
     if((fscanf(f, "%c ", &c) != 1) || (c != 'B') ||
-       (fscanf(f, "%d ", &wtc) != 1)) {
+    (fscanf(f, "%d ", &wtc) != 1)) {
       delete pdmap;
       return(0);
     }
     IvPBox *newbox = new IvPBox(dim, deg);
-
+    
     // The serialized weight count must match the storage allocated from the
     // header. Accepting a mismatch would either overrun the array or leave a
     // partially initialized box in the map.
@@ -279,39 +279,39 @@ PDMap* readPDMap(FILE *f, int dim, int boxCount, IvPDomain domain, int deg)
       delete pdmap;
       return(0);
     }
-
+    
     for(d=0; d<dim; d++) {
       // Field widths match the buffers, and failed reads are rejected before
       // their contents are inspected.
       if((fscanf(f, "%79s ", lowBuff) != 1) ||
-	 (fscanf(f, "%79s ", highBuff) != 1)) {
-	delete newbox;
-	delete pdmap;
-	return(0);
+      (fscanf(f, "%79s ", highBuff) != 1)) {
+        delete newbox;
+        delete pdmap;
+        return(0);
       }
       if(lowBuff[0]=='X') {         // Check for bound Xclusive
-	newbox->bd(d, 0) = 0;       // bound. If X is first char
-	lowBuff[0] = '+';           // set bound to exclusive (0)
+        newbox->bd(d, 0) = 0;       // bound. If X is first char
+        lowBuff[0] = '+';           // set bound to exclusive (0)
       }                             // and convert that X to a '+'.
       if(highBuff[0]=='X') {        // The '+' will be effectively
-	newbox->bd(d, 1) = 0;       // ignored by the atoi function.
-	highBuff[0] = '+';
+        newbox->bd(d, 1) = 0;       // ignored by the atoi function.
+        highBuff[0] = '+';
       }
       low = atoi(lowBuff);
       high = atoi(highBuff);
       int dim_pts = domain.getVarPoints(d);
       if((low < 0) || (high < low) || (high >= dim_pts)) {
-	delete newbox;
-	delete pdmap;
-	return(0);
+        delete newbox;
+        delete pdmap;
+        return(0);
       }
       newbox->setPTS(d, low, high);
     }
     for(d=0; d<wtc; d++) {
       if(fscanf(f, "%499s ", buff) != 1) {
-	delete newbox;
-	delete pdmap;
-	return(0);
+        delete newbox;
+        delete pdmap;
+        return(0);
       }
       newbox->wt(d) = atof(buff);
     }


### PR DESCRIPTION
# Bound the .ipf file parser

Malformed IvP function files trigger multiple stack and heap overflows

## Problem

`readFunctions()` and `readPDMap()` in
`ivp/src/lib_ivpbuild/IO_Utilities.cpp` parse a `.ipf` file with no bounds:

* the FUNCTION line loop (`:140-148`) keeps incrementing `buff_ix` after the
  guarded writes stop, so `buff[buff_ix]='\0'` lands at an unbounded offset;
* the AOF line loop (`:178-188`) has the same shape, and its guard is
  `< MAX_LINE_LENGTH` rather than `< MAX_LINE_LENGTH-1`;
* `while(c != '\n')` never terminates at end of file, because `fscanf` leaves
  `c` unchanged, so a truncated file is an infinite loop (`:141`);
* bare `fscanf("%s")` reads into `char lowBuff[80]`, `char highBuff[80]` and
  `char buff[500]` (`:247, 262`);
* `wtc` is read from the file and used as the loop bound for `newbox->wt(d)`
  (`:258-260`), which is an unchecked `m_wts[d]` (`ivp/src/lib_ivpcore/IvPBox.h:73, 76`);
* box bounds are read from the file and used to index the grid that
  `PDMap::updateGrid()` builds, with no check that they lie inside the domain.

## Impact

Stack and heap corruption with attacker chosen offsets, plus a hang, in any
program that reads a `.ipf` file it was given. There is no in tree consumer that
takes such a file from an untrusted place today, which is why the severity is
low, but `readFunction()` is an exported entry point of `libivpbuild`.

## Fix

* Both line loops stop at end of file and reserve room for the terminator.
* Every `fscanf("%s")` gains a field width matching its buffer.
* `wtc` is clamped to the weight count the box was actually built with.
* Box and gelbox bounds must lie inside the domain, and `readPDMap()` returns
  null when they do not.
* `readFunctions()` checks that return value, because `IvPFunction`'s
  constructor asserts on a null pdmap.

## Files touched

* `ivp/src/lib_ivpbuild/IO_Utilities.cpp`: bounded line loops, width limited `fscanf`, checked weight count, domain checked bounds, null pdmap handled

## Evidence

Before, stock build of the unpatched revision:

```
The six malformed files from the report, against a sanitised build:

  case1-function-line    rc=1    runtime error: index 4047 out of bounds
  case2-aof-line         rc=1    runtime error: index 3004 out of bounds
  case3-lowbuff          rc=1    ERROR: AddressSanitizer: stack-buffer-overflow
  case4-buff500          rc=1    ERROR: AddressSanitizer: stack-buffer-overflow
  case5-wtc              rc=1    ERROR: AddressSanitizer: heap-buffer-overflow
  case6-hang             rc=124  TIMEOUT (hang)
```

After, same test against this branch:

```
Same six files against this branch:

  case1-function-line    rc=0    survived
  case2-aof-line         rc=0    survived
  case3-lowbuff          rc=0    survived
  case4-buff500          rc=0    survived
  case5-wtc              rc=0    survived
  case6-hang             rc=0    survived
```

## Notes

Fixing the two reported line loops first exposed a further overflow downstream,
in `IvPGrid::initialize()` reached from `PDMap::updateGrid()`, because the
earlier crash had been masking it. That is why the domain bounds check and the
null pdmap handling are part of this patch: without them the file parser is
still not safe on the same inputs.
