### PR TITLE
alogsplit: reduce a log variable name to a safe file name

### DIFF
--- a/ivp/src/lib_logutils/SplitHandler.cpp
+++ b/ivp/src/lib_logutils/SplitHandler.cpp
@@ -72,6 +72,60 @@ SplitHandler::SplitHandler(string alog_file)
 //--------------------------------------------------------
 // Procedure: handle()
 
+//----------------------------------------------------------------
+// Procedure: safeVarFileName()
+//   Purpose: A variable name is simply the second whitespace delimited field
+//            of an .alog line, i.e. it is whatever the file says it is, and
+//            it is used below to build the path of a file which is opened for
+//            writing.  Replacing '/' alone is not enough: a backslash, a
+//            ".." segment or a drive prefix all resolve outside the split
+//            directory on Windows, and a Windows reserved device name is not
+//            a file at all.
+//
+//            Keep only characters which can appear in a MOOS variable name,
+//            refuse a name which is empty or is nothing but dots, and prefix
+//            the reserved device names so they cannot be addressed.
+
+static std::string safeVarFileName(const std::string& varname)
+{
+  std::string out;
+  bool all_dots = true;
+
+  for(unsigned int i=0; i<varname.length(); i++) {
+    char c = varname[i];
+    bool keep = ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) ||
+                ((c >= '0') && (c <= '9')) || (c == '_') || (c == '-') ||
+                (c == '.');
+    out += keep ? c : '_';
+    if(keep && (c != '.'))
+      all_dots = false;
+    if(!keep)
+      all_dots = false;
+  }
+
+  if(out == "")
+    return("");
+  if(all_dots)
+    return("");
+
+  // Windows reserved device names, with or without an extension
+  const char *reserved[] = {"CON","PRN","AUX","NUL",
+			    "COM1","COM2","COM3","COM4","COM5",
+			    "COM6","COM7","COM8","COM9",
+			    "LPT1","LPT2","LPT3","LPT4","LPT5",
+			    "LPT6","LPT7","LPT8","LPT9", 0};
+  std::string stem = out;
+  std::string::size_type dot = stem.find('.');
+  if(dot != std::string::npos)
+    stem = stem.substr(0, dot);
+  for(unsigned int i=0; reserved[i]; i++) {
+    if(toupper(stem) == reserved[i])
+      return("var_" + out);
+  }
+
+  return(out);
+}
+
 bool SplitHandler::handle()
 {
   bool ok = true;
@@ -185,8 +239,11 @@ bool SplitHandler::handleMakeSplitFiles()
     // Otherwise handle a normal line
     string varname = getVarName(line_raw);
     
-    // Replace slashes in variable names - filesystems get confused
-    varname = findReplace(varname, "/", "_");
+    // The name becomes part of a file path, so reduce it to something which
+    // cannot leave the split directory or name a device
+    varname = safeVarFileName(varname);
+    if(varname == "")
+      continue;
     
     // Reject any line that doesn't begin with a number
     string one_char = line_raw.substr(0,1);


### PR DESCRIPTION
# alogsplit: reduce a log variable name to a safe file name

Windows alog variable names can traverse outside the split directory

## Problem

A variable name in an `.alog` file is simply the second whitespace delimited
field of a line, so it is whatever the file says it is
(`ivp/src/lib_logutils/LogUtils.cpp:61-85`). `SplitHandler` turns it into a path
and opens it for writing:

```
varname = findReplace(varname, "/", "_");        // SplitHandler.cpp:186-189
...
string new_file = m_basedir + "/" + varname + ".klog";
FILE *new_ptr = fopen(new_file.c_str(), "a");    // SplitHandler.cpp:382-384
```

Replacing the forward slash is filesystem hygiene, not a path check. Backslashes,
`..` segments, drive prefixes such as `C:` and Windows reserved device names
(`CON`, `NUL`, `COM1`) all pass through untouched.

## Impact

On Windows the resulting path resolves outside the split directory, so a log
file can make the tool append to a chosen location, including a startup folder.
On POSIX the backslash is an ordinary character, so the practical impact there is
odd file names rather than traversal, which is why this is rated low. The
attacker supplies a log; the analyst only has to open it.

## Fix

Add `safeVarFileName()`, which

* keeps only characters that can appear in a MOOS variable name and maps
  everything else to `_`;
* refuses a name that is empty or nothing but dots;
* prefixes the Windows reserved device names so they cannot be addressed.

Lines whose name reduces to nothing are skipped, as malformed lines already are.

## Files touched

* `ivp/src/lib_logutils/SplitHandler.cpp`: add `safeVarFileName()` and use it instead of replacing only the forward slash

## Evidence

Before, stock build of the unpatched revision:

```
The report's crafted .alog, run through the stock tool. Files created inside
the split directory:

  CON.klog
  C:\Windows\Temp\absolute.klog
  NUL.klog
  ..\..\sibling.klog
  ..\..\..\..\Users\Public\Startup\payload.bat.klog
  ..\..\..\..\Windows\Temp\evil.klog

  backslash-bearing filenames created : 4
  drive-prefixed filename created     : 1
  reserved device names accepted      : 2
  forward-slash traversal neutralised : 1
```

After, same test against this branch:

```
Same .alog against this branch:

  C__Windows_Temp_absolute.klog
  var_CON.klog
  var_NUL.klog
  .._.._sibling.klog
  .._.._.._.._Users_Public_Startup_payload.bat.klog
  .._.._.._.._Windows_Temp_evil.klog

  backslash-bearing filenames created : 0
  drive-prefixed filename created     : 0
  reserved device names accepted      : 0
  forward-slash traversal neutralised : 4
```
