### PR TITLE
Safer system exec in iSay and uMemWatch

### DIFF
--- a/ivp/src/iSay/Sayer.cpp
+++ b/ivp/src/iSay/Sayer.cpp
@@ -23,7 +23,9 @@
 
 #include <cstdlib>
 #include <iterator>
+#include <vector>
 #include "MBUtils.h"
+#include "ProcessUtils.h"
 #include "VoiceUtils.h"
 #include "fileutil.h"
 #include "ACTable.h"
@@ -322,6 +324,7 @@ bool Sayer::sayUtterance()
   string srce  = utter.getSource();
   string text  = utter.getText();
   string file  = utter.getFile();
+  vector<string> argv;
   string cmd;
   //-------------------------------------------------
   // Case 1: Utterance is in the form of text
@@ -339,24 +342,33 @@ bool Sayer::sayUtterance()
     if(text != "")
       reportEvent("Say:" + text);
     
-    // Build the system command string (OSX)
+    // Build a program and literal argument vector (OSX).
     if((m_os_mode == "osx") || (m_os_mode == "both")) {
-      cmd  = "say -r " + str_rate;
-      if(voice != "")
-	cmd += " -v " + voice;
+      argv.push_back("say");
+      argv.push_back("-r");
+      argv.push_back(str_rate);
+      if(voice != "") {
+	argv.push_back("-v");
+	argv.push_back(voice);
+      }
 
       // Ex: $ say "[[volm 2]] Hello"
       if(m_volume != 1)
 	text = "[[volm " + doubleToStringX(m_volume) + "]] " + text;
 
-      cmd += " \"" + text + "\" ";
+      argv.push_back(text);
     }
-    // Build the system command string (Linux)
+    // Build a program and literal argument vector (Linux).
     else if((m_os_mode == "linux") || (m_os_mode == "both")) {
-      cmd = "espeak -s " + str_rate;
-      if(voice != "")
-	cmd += " -v " + voice;
-      cmd += "--stdin \"" + text + "\" ";
+      argv.push_back("espeak");
+      argv.push_back("-s");
+      argv.push_back(str_rate);
+      if(voice != "") {
+	argv.push_back("-v");
+	argv.push_back(voice);
+      }
+      argv.push_back("--stdin");
+      argv.push_back(text);
     }
 
   }
@@ -389,14 +401,18 @@ bool Sayer::sayUtterance()
       return(false);
     }
 
-    // Build the system command string (OSX)
+    // Build a program and literal argument vector (OSX).
     if((m_os_mode == "osx") || (m_os_mode == "both")) {
-      cmd = "afplay -v " + doubleToString(m_volume);
-      cmd += " " + found_file;
+      argv.push_back("afplay");
+      argv.push_back("-v");
+      argv.push_back(doubleToString(m_volume));
+      argv.push_back(found_file);
     }
-    // Build the system command string (Linux)
-    else if((m_os_mode == "linux") || (m_os_mode == "both"))
-      cmd = "aplay " + found_file;
+    // Build a program and literal argument vector (Linux).
+    else if((m_os_mode == "linux") || (m_os_mode == "both")) {
+      argv.push_back("aplay");
+      argv.push_back(found_file);
+    }
     
   }
   else {
@@ -404,19 +420,22 @@ bool Sayer::sayUtterance()
     return(false);
   }
 
-  // By adding an ampersand at the end of the command line, it runs the 
-  // job in the background thus returning immediately.
-  if(m_interval_policy == "from_start")
-    cmd += " &";
+  if(argv.empty()) {
+    reportRunWarning("No audio command configured for os_mode=" + m_os_mode);
+    return(false);
+  }
 
-  // We don't check the act on the result, but we get it anyway to avoid
-  // a compiler warning.
-  int result;
+  for(unsigned int i=0; i<argv.size(); i++) {
+    if(i > 0)
+      cmd += " ";
+    cmd += argv[i];
+  }
+
   Notify("ISAY_DEBUGA", cmd);
-  result = system(cmd.c_str());
+  bool result = runProcess(argv, m_interval_policy == "from_start");
   Notify("ISAY_DEBUGB", cmd);
 
-  if(result != 0) 
+  if(!result)
     cout << "Possible error in the iSay syscmd:" << cmd << endl;
 
   return(true);

--- a/ivp/src/lib_logutils/SplitHandler.cpp
+++ b/ivp/src/lib_logutils/SplitHandler.cpp
@@ -76,60 +76,6 @@ SplitHandler::SplitHandler(string alog_file)
 //--------------------------------------------------------
 // Procedure: handle()
 
-//----------------------------------------------------------------
-// Procedure: safeVarFileName()
-//   Purpose: A variable name is simply the second whitespace delimited field
-//            of an .alog line, i.e. it is whatever the file says it is, and
-//            it is used below to build the path of a file which is opened for
-//            writing.  Replacing '/' alone is not enough: a backslash, a
-//            ".." segment or a drive prefix all resolve outside the split
-//            directory on Windows, and a Windows reserved device name is not
-//            a file at all.
-//
-//            Keep only characters which can appear in a MOOS variable name,
-//            refuse a name which is empty or is nothing but dots, and prefix
-//            the reserved device names so they cannot be addressed.
-
-static std::string safeVarFileName(const std::string& varname)
-{
-  std::string out;
-  bool all_dots = true;
-
-  for(unsigned int i=0; i<varname.length(); i++) {
-    char c = varname[i];
-    bool keep = ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) ||
-                ((c >= '0') && (c <= '9')) || (c == '_') || (c == '-') ||
-                (c == '.');
-    out += keep ? c : '_';
-    if(keep && (c != '.'))
-      all_dots = false;
-    if(!keep)
-      all_dots = false;
-  }
-
-  if(out == "")
-    return("");
-  if(all_dots)
-    return("");
-
-  // Windows reserved device names, with or without an extension
-  const char *reserved[] = {"CON","PRN","AUX","NUL",
-			    "COM1","COM2","COM3","COM4","COM5",
-			    "COM6","COM7","COM8","COM9",
-			    "LPT1","LPT2","LPT3","LPT4","LPT5",
-			    "LPT6","LPT7","LPT8","LPT9", 0};
-  std::string stem = out;
-  std::string::size_type dot = stem.find('.');
-  if(dot != std::string::npos)
-    stem = stem.substr(0, dot);
-  for(unsigned int i=0; reserved[i]; i++) {
-    if(toupper(stem) == reserved[i])
-      return("var_" + out);
-  }
-
-  return(out);
-}
-
 bool SplitHandler::handle()
 {
   bool ok = true;
@@ -245,7 +191,7 @@ bool SplitHandler::handleMakeSplitFiles()
     
     // The name becomes part of a file path, so reduce it to something which
     // cannot leave the split directory or name a device
-    varname = safeVarFileName(varname);
+    varname = safeFileName(varname, "var_");
     if(varname == "")
       continue;
     
@@ -721,4 +667,3 @@ string SplitHandler::nodeRecordToViewVessel(string str)
   return(view_vessel_str);
   
 }
-

--- a/ivp/src/lib_mbutil/CMakeLists.txt
+++ b/ivp/src/lib_mbutil/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(SRC
   LatLonFormatUtils.cpp
   OpenURL.cpp
   BundleOut.cpp
+  ProcessUtils.cpp
   )
 
 SET(HEADERS
@@ -58,6 +59,7 @@ SET(HEADERS
   LatLonFormatUtils.h
   OpenURL.h
   BundleOut.h
+  ProcessUtils.h
 )
 
 # Build Library

--- a/ivp/src/lib_mbutil/MBUtils.cpp
+++ b/ivp/src/lib_mbutil/MBUtils.cpp
@@ -828,6 +828,48 @@ string toupper(const string& str)
 }
 
 //----------------------------------------------------------------
+// Procedure: safeFileName()
+//   Purpose: Convert arbitrary text to a portable, single filename component.
+//            Unsafe characters are replaced, dot-only names are rejected, and
+//            Windows reserved device names are prefixed.
+
+string safeFileName(const string& str, const string& reserved_prefix)
+{
+  string result;
+  bool all_dots = true;
+
+  for(unsigned int i=0; i<str.length(); i++) {
+    char c = str[i];
+    bool keep = ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) ||
+                ((c >= '0') && (c <= '9')) || (c == '_') || (c == '-') ||
+                (c == '.');
+    result += keep ? c : '_';
+    if(!keep || (c != '.'))
+      all_dots = false;
+  }
+
+  if(result == "" || all_dots)
+    return("");
+
+  string stem = result;
+  string::size_type dot = stem.find('.');
+  if(dot != string::npos)
+    stem = stem.substr(0, dot);
+
+  const char *reserved[] = {"CON", "PRN", "AUX", "NUL",
+			    "COM1", "COM2", "COM3", "COM4", "COM5",
+			    "COM6", "COM7", "COM8", "COM9",
+			    "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",
+			    "LPT6", "LPT7", "LPT8", "LPT9", 0};
+  for(unsigned int i=0; reserved[i]; i++) {
+    if(toupper(stem) == reserved[i])
+      return(reserved_prefix + result);
+  }
+
+  return(result);
+}
+
+//----------------------------------------------------------------
 // Procedure: truncString()
 
 string truncString(const string& str, unsigned int newlen, string style)
@@ -2994,4 +3036,3 @@ string digitsOnly(const string& str)
 }
 
   
-

--- a/ivp/src/lib_mbutil/MBUtils.h
+++ b/ivp/src/lib_mbutil/MBUtils.h
@@ -82,6 +82,8 @@ std::string stripBlankEnds(const std::string&);
 std::string stripBlankEnd(const std::string&);
 std::string tolower(const std::string&);
 std::string toupper(const std::string&);
+std::string safeFileName(const std::string& str,
+			 const std::string& reserved_prefix = "file_");
 std::string truncString(const std::string&, unsigned int newlen, 
 			std::string="");
 std::string boolToString(bool);
@@ -222,4 +224,3 @@ bool isValidTurn(const std::string&);
 std::string digitsOnly(const std::string&);
 
 #endif
-

--- a/ivp/src/lib_mbutil/ProcessUtils.cpp
+++ b/ivp/src/lib_mbutil/ProcessUtils.cpp
@@ -1,0 +1,103 @@
+/*****************************************************************/
+/*    NAME: Conlan Cesar                                         */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: ProcessUtils.cpp                                     */
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*****************************************************************/
+
+#include <cerrno>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "ProcessUtils.h"
+
+using namespace std;
+
+//---------------------------------------------------------
+// Procedure: execProcess
+
+static void execProcess(const vector<string>& argv)
+{
+  vector<char*> cargv;
+  for(unsigned int i=0; i<argv.size(); i++)
+    cargv.push_back(const_cast<char*>(argv[i].c_str()));
+  cargv.push_back(0);
+
+  execvp(cargv[0], &cargv[0]);
+  _exit(127);
+}
+
+//---------------------------------------------------------
+// Procedure: execProcessToFile
+
+static void execProcessToFile(const vector<string>& argv, const string& outfile)
+{
+  if(!outfile.empty()) {
+    int fd = open(outfile.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if(fd < 0)
+      _exit(127);
+    if(dup2(fd, STDOUT_FILENO) < 0)
+      _exit(127);
+    close(fd);
+  }
+
+  execProcess(argv);
+}
+
+//---------------------------------------------------------
+// Procedure: waitForProcess
+
+static bool waitForProcess(pid_t pid)
+{
+  int status = 0;
+  while(waitpid(pid, &status, 0) < 0) {
+    if(errno != EINTR)
+      return(false);
+  }
+
+  return(WIFEXITED(status) && (WEXITSTATUS(status) == 0));
+}
+
+//---------------------------------------------------------
+// Procedure: runProcess
+
+bool runProcess(const vector<string>& argv, bool detached)
+{
+  return(runProcessToFile(argv, "", detached));
+}
+
+//---------------------------------------------------------
+// Procedure: runProcessToFile
+
+bool runProcessToFile(const vector<string>& argv, const string& outfile,
+                      bool detached)
+{
+  if(argv.empty())
+    return(false);
+
+  pid_t pid = fork();
+  if(pid < 0)
+    return(false);
+
+  if(pid == 0) {
+    if(!detached)
+      execProcessToFile(argv, outfile);
+
+    // The intermediate child exits immediately. Its child is adopted and
+    // reaped by the system, so a detached launch cannot leave a zombie behind.
+    pid_t grandchild = fork();
+    if(grandchild == 0)
+      execProcessToFile(argv, outfile);
+    _exit(grandchild < 0 ? 127 : 0);
+  }
+
+  return(waitForProcess(pid));
+}

--- a/ivp/src/lib_mbutil/ProcessUtils.h
+++ b/ivp/src/lib_mbutil/ProcessUtils.h
@@ -1,0 +1,30 @@
+/*****************************************************************/
+/*    NAME: Conlan Cesar                                         */
+/*    ORGN: Dept of Mechanical Engineering, MIT, Cambridge MA    */
+/*    FILE: ProcessUtils.h                                       */
+/*                                                               */
+/* This file is part of IvP Helm Core Libs                       */
+/*                                                               */
+/* IvP Helm Core Libs is free software: you can redistribute it  */
+/* and/or modify it under the terms of the Lesser GNU General    */
+/* Public License as published by the Free Software Foundation,  */
+/* either version 3 of the License, or (at your option) any      */
+/* later version.                                                */
+/*****************************************************************/
+
+#ifndef PROCESS_UTILS_HEADER
+#define PROCESS_UTILS_HEADER
+
+#include <string>
+#include <vector>
+
+// Run argv[0] with the remaining vector entries as literal arguments. No
+// command shell is used. A detached process does not leave a zombie child.
+bool runProcess(const std::vector<std::string>& argv, bool detached=false);
+
+// As above, with stdout redirected to outfile. Pass an empty outfile to leave
+// stdout unchanged. A detached process does not leave a zombie child.
+bool runProcessToFile(const std::vector<std::string>& argv,
+                      const std::string& outfile, bool detached=false);
+
+#endif

--- a/ivp/src/uMemWatch/MemWatch.cpp
+++ b/ivp/src/uMemWatch/MemWatch.cpp
@@ -23,8 +23,11 @@
 
 #include <cstdlib>
 #include <iterator>
+#include <cstdio>
+#include <vector>
 #include "MBUtils.h"
 #include "ACTable.h"
+#include "ProcessUtils.h"
 #include "MemWatch.h"
 #include "FileBuffer.h"
 
@@ -173,23 +176,21 @@ void MemWatch::measureMemory()
   if(ix >= m_app.size())
     ix = 0;
 
-  // Part 2: Build the system call from the app and pid info
-  //         Make the system call
+  // Part 2: Run appmem & write output to file
   string app = m_app[ix];
   string pid = m_pid[ix];
-  string tmp_file = ".mem_info_" + tolower(app) + "_" + pid;
-  string syscall = "appmem.sh --pid=" + m_pid[ix];
-  syscall += " > " + tmp_file;  
-  system(syscall.c_str());
+  string tmp_file = ".mem_info_" + safeFileName(tolower(app)) + "_" +
+                    safeFileName(pid);
+  vector<string> argv;
+  argv.push_back("appmem.sh");
+  argv.push_back("--pid=" + pid);
+  runProcessToFile(argv, tmp_file);
 
   // Part 3: Get the output of the system call
   vector<string> lines = fileBuffer(tmp_file);
+  remove(tmp_file.c_str());
   if(lines.size() == 0)
     return;
-
-  // Part 4: Remove temporary file holding first sys call output
-  string syscall_rm = "rm -f " + tmp_file + " &";
-  system(syscall_rm.c_str());
   
   // Part 5: Intpret the output. Normall this is just an integer
   //         representing the mem size in Kilobytes. But we also
@@ -418,8 +419,5 @@ bool MemWatch::buildReport()
   
   return(true);
 }
-
-
-
 
 


### PR DESCRIPTION
Calls to `system` are liable to being injected & interpreted by a shell. This can lead to arbitrary RCEs. See the exploits in #120 and #121. 

Those PRs both solve the issue for their respective apps, but since the exploit is so similar, implemented it in mbutil. I then updated the apps to call that new method. 

I also moved the filename sanitizer into mbutil since it was useful here too.

Fixes #120
Fixes #121